### PR TITLE
meta-debian: rename perl-native-runtime

### DIFF
--- a/recipes-debian/automake/automake_debian.bb
+++ b/recipes-debian/automake/automake_debian.bb
@@ -36,7 +36,7 @@ RDEPENDS_${PN} += "\
 	perl-module-threads \
 	perl-module-vars \
 "
-RDEPENDS_${PN}_class-native = "autoconf-native perl-native-runtime"
+RDEPENDS_${PN}_class-native = "autoconf-native hostperl-runtime-native"
 
 # regenerate dependent files created by aclocal and automake
 do_configure_prepend() {

--- a/recipes-debian/libcap/libcap_debian.bb
+++ b/recipes-debian/libcap/libcap_debian.bb
@@ -10,10 +10,10 @@ LICENSE = "BSD | GPLv2"
 LIC_FILES_CHKSUM = "file://License;md5=3f84fd6f29d453a56514cb7e4ead25f1"
 
 DPN = "libcap2"
-DEPENDS = "attr perl-native-runtime"
+DEPENDS = "attr hostperl-runtime-native"
 DEPENDS += "${@base_contains('DISTRO_FEATURES', 'pam', 'libpam', '', d)}"
 # attr and pam are disabled by EXTRA_OEMAKE_class-native
-DEPENDS_class-native = "perl-native-runtime"
+DEPENDS_class-native = "hostperl-runtime-native"
 
 inherit debian-package
 inherit lib_package

--- a/recipes-debian/openssl/openssl_debian.bb
+++ b/recipes-debian/openssl/openssl_debian.bb
@@ -25,7 +25,7 @@ file://find.pl \
 "
 
 # "${S}/Configure" is written by perl script
-DEPENDS = "perl-native-runtime"
+DEPENDS = "hostperl-runtime-native"
 
 # CFLAG replaces the second parameters (next to gcc:) of the target config
 # in Configure (see do_configure). We simply use the same options as OE-Core


### PR DESCRIPTION
The code in native.bbclass in meta adds -native suffix
to the package names that don't have it. perl-native-runtime
becomes perl-native-runtime-native because of this.

Renamed perl-native-runtime -> hostperl-runtime-native to avoid
mangling it and to conform with the naming convetion for native
packages.

(From meata, master branch, commit 675ff42c6030b33ff49dd2ec5ff9d157f23b48dc )

Signed-off-by: Hoang Trong Nghia <nghia.hoangtrong@toshiba-tsdv.com>