### PR TITLE
linux-base: Mapping between i386/x86_64 and x86 for kernel ARCH

### DIFF
--- a/recipes-kernel/linux/linux-base_git.bb
+++ b/recipes-kernel/linux/linux-base_git.bb
@@ -64,14 +64,22 @@ ${@base_conditional('LINUX_CONFIG_APPEND', '', '', 'file://${LINUX_CONFIG_APPEND
 do_configure_prepend() {
 	rm -f ${WORKDIR}/defconfig
 
+	# When ARCH is set to i386 or x86_64, we need to map ARCH to the real name of src
+	# dir (x86) under arch/ of kenrel tree, so that we can find correct source to copy.
+	if [ "${ARCH}" = "i386" ] || [ "${ARCH}" = "x86_64" ]; then
+		KERNEL_SRCARCH=x86
+	else
+		KERNEL_SRCARCH=${ARCH}
+	fi
+
 	if [ -n "${LINUX_CONFIG}" ]; then
 		DEFCONFIG=${WORKDIR}/${LINUX_CONFIG}
 	elif [ -n "${LINUX_DEFCONFIG}" ]; then
-		DEFCONFIG=${S}/arch/${ARCH}/configs/${LINUX_DEFCONFIG}
+		DEFCONFIG=${S}/arch/${KERNEL_SRCARCH}/configs/${LINUX_DEFCONFIG}
 	else
 		bbfatal "Both LINUX_DEFCONFIG and LINUX_CONFIG are not defined.
        Please set one of them at lease.
-       LINUX_DEFCONFIG: a defconfig file in ${S}/arch/${ARCH}/configs
+       LINUX_DEFCONFIG: a defconfig file in ${S}/arch/${KERNEL_SRCARCH}/configs
        LINUX_CONFIG: a config file in FILESPATH"
 	fi
 	if [ ! -f ${DEFCONFIG} ]; then


### PR DESCRIPTION
The patch (from meta, branch master, commit c0e9f2d)
sets ARCH i386 or x86_64 explicitly to configure task
to avoid this host contamination. So kernel configuration step
is also changed so that it can map i386 and x64 back to arch/x86.

Signed-off-by: Hoang Trong Nghia <nghia.hoangtrong@toshiba-tsdv.com>