### PR TITLE
Update README.md cd before setup build dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ git checkout jethro
 $ git clone https://github.com/meta-debian/meta-debian.git
 $ cd meta-debian
 $ git checkout jethro
+$ cd ../../
 ```
 
 Setup build directory.


### PR DESCRIPTION
A change directory is needed before `setup build directory`. This patch fix:
```
bash: ./poky/oe-init-build-env: No such file or directory
```