### PR TITLE
Make postinst run at do_rootfs and the first boot

### DIFF
--- a/recipes-debian/autotools-dev/autotools-dev_debian.bb
+++ b/recipes-debian/autotools-dev/autotools-dev_debian.bb
@@ -25,6 +25,9 @@ PV = "20140911.1"
 
 inherit allarch
 
+# Makefile doesn't have target clean
+CLEANBROKEN = "1"
+
 do_install() {
 	install -d ${D}${datadir}/misc
 	install config.guess config.sub ${D}${datadir}/misc

--- a/recipes-debian/dbus/dbus_debian.bb
+++ b/recipes-debian/dbus/dbus_debian.bb
@@ -83,10 +83,6 @@ pkg_postinst_dbus() {
 		fi
 		systemctl $OPTS mask dbus-1.service
 	fi
-
-	if [ -z "$D" ] && [ -e /etc/init.d/populate-volatile.sh ] ; then
-		/etc/init.d/populate-volatile.sh update
-	fi
 }
 
 # --disable-selinux: Don't use selinux support

--- a/recipes-debian/gconf/files/add_option_change_root_path.patch
+++ b/recipes-debian/gconf/files/add_option_change_root_path.patch
@@ -1,0 +1,63 @@
+diff --git a/debian/gconf-schemas b/debian/gconf-schemas
+old mode 100644
+new mode 100755
+index dc16c0a..544f554
+--- a/debian/gconf-schemas
++++ b/debian/gconf-schemas
+@@ -20,6 +20,7 @@ parser.add_option("--register-all", action="store_true", dest="register_all",
+                    default=False)
+ parser.add_option("--no-signal", action="store_false", default=True, dest="signal",
+                   help="do not send SIGHUP the running gconfd-2 processes")
++parser.add_option("--root", dest="root", default="")
+ (options, args) = parser.parse_args()
+ 
+ if options.register==None and not options.register_all:
+@@ -30,8 +31,8 @@ if 'DPKG_RUNNING_VERSION' in os.environ and not options.register_all:
+     # Do nothing, it will be done in the trigger
+     sys.exit(0)
+ 
+-schema_location="/usr/share/gconf/schemas"
+-defaults_dest="/var/lib/gconf/defaults"
++schema_location = options.root + "/usr/share/gconf/schemas"
++defaults_dest = options.root + "/var/lib/gconf/defaults"
+ 
+ schemas = [ ]
+ if options.register_all:
+@@ -47,9 +48,6 @@ else:
+     else:
+       sys.stderr.write('Warning: %s could not be found.\n'%schema)
+ 
+-if os.geteuid():
+-  parser.error("You must be root to launch this program.")
+-
+ if options.register_all:
+   options.register=True
+   for f in os.listdir(defaults_dest):
+diff --git a/debian/update-gconf-defaults b/debian/update-gconf-defaults
+index 022c527..1a366b1 100644
+--- a/debian/update-gconf-defaults
++++ b/debian/update-gconf-defaults
+@@ -20,6 +20,7 @@ parser.add_option("--no-signal", action="store_false", default=True, dest="signa
+                   help="do not send SIGHUP the running gconfd-2 processes")
+ parser.add_option("--only-if-changed", action="store_true", default=False, dest="ifchanged",
+                   help="only regenerate configuration if needed")
++parser.add_option("--root", dest="root", default="")
+ 
+ (options, args) = parser.parse_args()
+ 
+@@ -28,9 +29,13 @@ if 'DPKG_RUNNING_VERSION' in os.environ and options.signal:
+     # Do nothing, it will be done in the trigger
+     sys.exit(0)
+ 
++
++options.source_dir = options.root + options.source_dir
++options.dest_dir = options.root + options.dest_dir
++
+ if options.mandatory:
+-    options.source_dir="/usr/share/gconf/mandatory"
+-    options.dest_dir="/var/lib/gconf/debian.mandatory"
++    options.source_dir = options.root + "/usr/share/gconf/mandatory"
++    options.dest_dir = options.root + "/var/lib/gconf/debian.mandatory"
+ 
+ if not os.path.isdir(options.source_dir):
+     parser.error("Source directory does not exist.")

--- a/recipes-debian/lxc/lxc_debian.bb
+++ b/recipes-debian/lxc/lxc_debian.bb
@@ -67,10 +67,3 @@ RDEPENDS_${PN} = "bash \
                   perl-module-overload \
                   perl-module-exporter-heavy \
                   "
-
-pkg_postinst_${PN}() {
-        if [ -z "$D" ] && [ -e ${sysconfdir}/init.d/populate-volatile.sh ] ; then
-                ${sysconfdir}/init.d/populate-volatile.sh update
-        fi
-}
-

--- a/recipes-debian/lxc/lxc_debian.bb
+++ b/recipes-debian/lxc/lxc_debian.bb
@@ -24,6 +24,9 @@ EXTRA_OECONF = "--disable-rpath \
                 --enable-bash --disable-selinux --disable-python --with-distro=debian \
                 --with-init-script=sysvinit,systemd \
                 "
+PACKAGECONFIG ??= ""
+# According to debian/control, lxc requires lua5.2 but not lua5.1
+PACKAGECONFIG[lua] = "--enable-lua,--disable-lua,lua5.2"
 
 do_install() {
         oe_runmake 'DESTDIR="${D}"' 'SYSTEMD_UNIT_DIR="${systemd_system_unitdir}"' install

--- a/recipes-debian/nss/files/nss-regen-chk.init
+++ b/recipes-debian/nss/files/nss-regen-chk.init
@@ -1,0 +1,18 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:		nss-regen-chk
+# Required-Start:	$remote_fs
+# Required-Stop:
+# Default-Start:	S
+# Default-Stop:
+### END INIT INFO
+
+@BINDIR@/signlibs.sh
+
+if [ -f @SBINDIR@/update-rc.d ]; then
+	@SBINDIR@/update-rc.d -f nss-regen-chk remove
+elif [ -f @BASE_SBINDIR@/insserv ]; then
+	@BASE_SBINDIR@/insserv -f -r nss-regen-chk
+else
+	find /etc/rc*.d -name "*nss-regen-chk" -exec rm -f {} \;
+fi

--- a/recipes-debian/nss/files/nss-regen-chk.service
+++ b/recipes-debian/nss/files/nss-regen-chk.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Generate nss checksum files
+DefaultDependencies=no
+After=systemd-remount-fs.service systemd-tmpfiles-setup.service tmp.mount
+Before=sysinit.target
+
+[Service]
+Type=oneshot
+ExecStart=@BINDIR@/signlibs.sh
+ExecStartPost=@BASE_BINDIR@/systemctl disable nss-regen-chk.service
+RemainAfterExit=No
+
+[Install]
+WantedBy=basic.target
+WantedBy=sysinit.target


### PR DESCRIPTION
After removed dpkg-configure.service, we re-checked all of postinsts in recipe to make sure they still can work correctly.