### PR TITLE
kernel:qemuarm: Enable DEVTMPFS_MOUNT

### DIFF
--- a/recipes-kernel/linux/files/qemuarm.config
+++ b/recipes-kernel/linux/files/qemuarm.config
@@ -1,2 +1,6 @@
 # versatilepb machine needs ARM EABI support
 CONFIG_AEABI=y
+
+# automatically mount the devtmpfs filesystem at /dev
+CONFIG_DEVTMPFS=y
+CONFIG_DEVTMPFS_MOUNT=y


### PR DESCRIPTION
When we follow the README.md to build a minimal OS for qemuarm.
The booting is hung after messages:
  | VFS: Mounted root (ext4 filesystem) on device 254:0.
  | Freeing unused kernel memory: 140K
  | mkdir: can't create directory '/dev/pts': File exists
  | random: nonblocking pool is initialized
The DEVTMPFS_MOUNT is not enabled by default in kernel defconfig
for arm. So, add enabling the config to qemuarm.config file to
automatically mount the devtmpfs filesystem at /dev.

Signed-off-by: Hoang Van Tuyen <tuyen.hoangvan@toshiba-tsdv.com>