### PR TITLE
Add "license-checksum" to ERROR_QA

### DIFF
--- a/conf/distro/deby.conf
+++ b/conf/distro/deby.conf
@@ -92,7 +92,8 @@ ERROR_QA = "dev-so debug-deps dev-deps debug-files arch pkgconfig la perms \
             useless-rpaths rpaths staticdev ldflags pkgvarcheck already-stripped \
             compile-host-path dep-cmp installed-vs-shipped install-host-path \
             packages-list perm-config perm-line perm-link pkgv-undefined \
-            pn-overrides split-strip var-undefined version-going-backwards"
+            pn-overrides split-strip var-undefined version-going-backwards \
+            license-checksum"
 
 #
 # distro/poky-tiny.conf based configuration

--- a/recipes-debian/tzdata/tzdata_debian.bb
+++ b/recipes-debian/tzdata/tzdata_debian.bb
@@ -11,8 +11,8 @@ PR = "r0"
 inherit debian-package
 PV = "2017c"
 
-LICENSE = "PD & BSD & BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=ef1a352b901ee7b75a75df8171d6aca7"
+LICENSE = "PD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c679c9d6b02bc2757b3eaf8f53c43fba"
 
 DEPENDS = "zic-native"
 


### PR DESCRIPTION
Since '1da8f52', poky has converted package_qa_check_license to use standard QA check
configuration interface through package_qa_handle_error.
If we want to see license-checksum's error message during bitbake-ing,
we need to add it to ERROR_QA.