### PR TITLE
debian-source.bbclass: Make class flexible to get layer path of meta-debian

### DIFF
--- a/classes/debian-source.bbclass
+++ b/classes/debian-source.bbclass
@@ -75,8 +75,8 @@ def save_to_file(package, dpv, pv, repack_pv, directory, files, md5sum, sha256su
         return
 
     import os
-    corebase = d.getVar('COREBASE', True)
-    filepath = '%s/meta-debian/recipes-debian/sources/%s.inc' % (corebase, package)
+    layerdir = d.getVar('LAYERDIR_DEBIAN', True)
+    filepath = '%s/recipes-debian/sources/%s.inc' % (layerdir, package)
     if not os.path.isfile(filepath):
         return
 
@@ -176,8 +176,8 @@ def get_pkg_dpv_map(d):
     import os
 
     pkg_dpv_map = {}
-    corebase = d.getVar('COREBASE', True)
-    sources_dir = os.path.join(corebase, 'meta-debian/recipes-debian/sources')
+    layerdir = d.getVar('LAYERDIR_DEBIAN', True)
+    sources_dir = os.path.join(layerdir, 'recipes-debian/sources')
 
     if not os.path.isdir(sources_dir):
         return {}

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,3 +16,6 @@ LAYERVERSION_debian = "1"
 LAYERDEPENDS_debian = "core"
 
 LAYERSERIES_COMPAT_debian = "thud"
+
+# Set a variable to keep the path of layer meta-debian
+LAYERDIR_DEBIAN = '${@os.path.normpath("${LAYERDIR}")}'


### PR DESCRIPTION
Currently, debian-source.bbclass get the path of layer meta-debian as
'poky/meta-debian'. This is not a good implementation if user wants to put
meta-debian in a different path or rename the folder name.

Make it be flexible by using LAYERDIR to get the layer path.