### PR TITLE
debian-package.bbclass: Update checking DEBIAN_QUILT_PATCHES

### DIFF
--- a/classes/debian-package.bbclass
+++ b/classes/debian-package.bbclass
@@ -82,8 +82,9 @@ debian_patch_quilt() {
 
 	# some source packages don't have patch
 	if [ -z "${DEBIAN_QUILT_PATCHES}" ]; then
-		if [ -d ${DEBIAN_UNPACK_DIR}/debian/patches ]; then
-			bbfatal "DEBIAN_QUILT_PATCHES is null, but ${DEBIAN_UNPACK_DIR}/debian/patches exists"
+		if [ -f ${DEBIAN_UNPACK_DIR}/debian/patches/series \
+			-s ${DEBIAN_UNPACK_DIR}/debian/patches/series ]; then
+			bbfatal "DEBIAN_QUILT_PATCHES is null, but ${DEBIAN_UNPACK_DIR}/debian/patches/series exists"
 		fi
 		bbnote "no debian patch exists in the source tree, nothing to do"
 		return


### PR DESCRIPTION
In the Debian source package, debian/patches directory may be empty, or
debian/parches/series with no data.
The current process checks the contents of DEBIAN_QUILT_PATCHES and the
existence of a directory, but in the above case an error occurs.

This fix switched to the check process of debian/parches/series file.

Signed-off-by: Nobuhiro Iwamatsu <nobuhiro.iwamatsu@miraclelinux.com>