### PR TITLE
debian-package: Change processing when patches/series file was empty

### DIFF
--- a/classes/debian-package.bbclass
+++ b/classes/debian-package.bbclass
@@ -98,10 +98,10 @@ debian_patch_quilt() {
 		FOUND_PATCHES="$(debian_find_patches)"
 		if [ -z "${FOUND_PATCHES}" ]; then
 			bbnote "series is empty, nothing to do"
-			return
 		else
-			bbfatal "series is empty, but some patches found"
+			bbnote "series is empty, but some patches found"
 		fi
+		return
 	fi
 
 	# apply patches


### PR DESCRIPTION
If the content of the patches/series file was empty and there is patches, the
patch application process will fail. In this case there is no need to set an
error.

Signed-off-by: Nobuhiro Iwamatsu <nobuhiro.iwamatsu@miraclelinux.com>