### PR TITLE
recipes-debian/flex: Disable reallocarray

### DIFF
--- a/recipes-debian/flex/flex_debian.bb
+++ b/recipes-debian/flex/flex_debian.bb
@@ -30,6 +30,7 @@ DEBIAN_PATCH_TYPE = "nopatch"
 M4 = "${bindir}/m4"
 M4_class-native = "${STAGING_BINDIR_NATIVE}/m4"
 EXTRA_OECONF += "ac_cv_path_M4=${M4}"
+EXTRA_OECONF += "ac_cv_func_reallocarray=no"
 EXTRA_OEMAKE += "m4=${STAGING_BINDIR_NATIVE}/m4"
 
 EXTRA_OEMAKE += "${@bb.utils.contains('PTEST_ENABLED', '1', 'FLEX=${STAGING_BINDIR_NATIVE}/flex', '', d)}"


### PR DESCRIPTION
Fix undefined reference to `reallocarray'
by disabling reallocarray.

reference:
https://github.com/buildroot/buildroot/commit/ffbd8dfb8a1fcbc0cb209f8ede4841c543524525