### PR TITLE
glibc-locale: overwrite default PV

### DIFF
--- a/recipes-debian/glibc/glibc-locale_debian.bb
+++ b/recipes-debian/glibc/glibc-locale_debian.bb
@@ -1,1 +1,2 @@
 require recipes-core/glibc/glibc-locale.inc
+require recipes-debian/sources/glibc.inc


### PR DESCRIPTION
Since commit 53b3e8c9d6e34f076a006df41cd2854b3cb30c71,
meta/recipes-core/glibc/glibc-common.inc set PV in the file.

So, if meta-debian and poky use different glibc versions, glibc-locale
package vesion will be set to Poky's glibc version.

```
$ bitbake-layers show-recipes | grep -A3 glibc
glibc:
  meta-debian          2.28
  meta                 2.29
glibc-locale:
  meta-debian          2.29
  meta                 2.29
```

In the case, glibc-locale package's PV is 2.29, but the package is
created from glibc 2.28 package.

This patch recipes-debian/sources/glibc.inc file to re-set PV to
debian glibc version.