### PR TITLE
busybox: Add ptest failures fix patches

### DIFF
--- a/recipes-debian/busybox/busybox_debian.bb
+++ b/recipes-debian/busybox/busybox_debian.bb
@@ -51,4 +51,5 @@ SRC_URI += " \
            file://rcS \
            file://rcK \
            file://makefile-libbb-race.patch \
+           file://0001-testsuite-check-uudecode-before-using-it.patch \
 "

--- a/recipes-debian/busybox/busybox_debian.bb
+++ b/recipes-debian/busybox/busybox_debian.bb
@@ -52,4 +52,5 @@ SRC_URI += " \
            file://rcK \
            file://makefile-libbb-race.patch \
            file://0001-testsuite-check-uudecode-before-using-it.patch \
+           file://0001-dc.tests-fix-two-test-case-to-also-depend-on-DC_BIG.patch \
 "


### PR DESCRIPTION
This PR contains 3 commits to fix test errors. 
Every commit added a patch name to SRC_URI variable because Poky has a patch. So it didn't needed to write a new patch to fix test errors.

The 0001-testsuite-check-uudecode-before-using-it.patch for tar command test , 0001-du-l-works-fix-to-use-145-instead-of-144.patch for du command test, and 0001-dc.tests-fix-two-test-case-to-also-depend-on-DC_BIG.patch for dc command test.




