### PR TITLE
deby.inc: Fix the conflict when build SDK with "-c populate_sdk"

### DIFF
--- a/conf/distro/deby.inc
+++ b/conf/distro/deby.inc
@@ -34,3 +34,6 @@ TCMODE ?= "deby"
 
 # preferred providers and versions
 require conf/distro/include/debian-preferred-provider.inc
+
+# WORKAROUND for https://bugzilla.yoctoproject.org/show_bug.cgi?id=13338
+TOOLCHAIN_TARGET_TASK_remove = "target-sdk-provides-dummy"


### PR DESCRIPTION
"bitbake -c populate_sdk core-image-minimal" automatically adds packages from
image package list to SDK package list.
This can cause a conflict if image package list and target-sdk-provides-dummy
provide same packages.
Temporarily avoid this problem by remove target-sdk-provides-dummy out of
TOOLCHAIN_TARGET_TASK.

Upstream bug: https://bugzilla.yoctoproject.org/show_bug.cgi?id=13338