### PR TITLE
linux-base: Refresh patches for v4.19.60-cip7

### DIFF
--- a/recipes-kernel/linux/files/powerpc-Disable-attribute-alias-warnings-from-gcc8.patch
+++ b/recipes-kernel/linux/files/powerpc-Disable-attribute-alias-warnings-from-gcc8.patch
@@ -1,14 +1,16 @@
-From 59e401ffeda487d9b3bd092199ec9a98faf5abfe Mon Sep 17 00:00:00 2001
-From: Khem Raj <raj.khem@gmail.com>
-Date: Fri, 4 May 2018 09:46:42 -0700
-Subject: [PATCH 1/2] powerpc: Disable attribute-alias warnings from gcc8
-
-Fixes
-alias between functions of incompatible types warnings
-which are new with gcc8
-
-Signed-off-by: Khem Raj <raj.khem@gmail.com>
-Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+# base patch: http://lists.openembedded.org/pipermail/openembedded-core/2018-June/151673.html
+#
+# From 59e401ffeda487d9b3bd092199ec9a98faf5abfe Mon Sep 17 00:00:00 2001
+# From: Khem Raj <raj.khem@gmail.com>
+# Date: Fri, 4 May 2018 09:46:42 -0700
+# Subject: [PATCH 1/2] powerpc: Disable attribute-alias warnings from gcc8
+#
+# Fixes
+# alias between functions of incompatible types warnings
+# which are new with gcc8
+#
+# Signed-off-by: Khem Raj <raj.khem@gmail.com>
+# Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
 ---
  arch/powerpc/kernel/Makefile | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
@@ -25,8 +27,5 @@ index 1b6bc7fba996..7fab5ab9edc2 100644
 +CFLAGS_ptrace.o		+= -DUTS_MACHINE='"$(UTS_MACHINE)"' $(call cc-disable-warning, attribute-alias)
 +CFLAGS_syscalls.o	+= $(call cc-disable-warning, attribute-alias)
  
- subdir-ccflags-$(CONFIG_PPC_WERROR) := -Werror
- 
--- 
-2.5.0
-
+ # Disable clang warning for using setjmp without setjmp.h header
+ CFLAGS_crash.o		+= $(call cc-disable-warning, builtin-requires-header)

--- a/recipes-kernel/linux/files/powerpc-ptrace-Disable-array-bounds-warning-with-gcc.patch
+++ b/recipes-kernel/linux/files/powerpc-ptrace-Disable-array-bounds-warning-with-gcc.patch
@@ -1,13 +1,15 @@
-From 8632f470f02c70d9501ae21f57740ea23c14773f Mon Sep 17 00:00:00 2001
-From: Khem Raj <raj.khem@gmail.com>
-Date: Fri, 4 May 2018 09:50:05 -0700
-Subject: [PATCH 2/2] powerpc/ptrace: Disable array-bounds warning with gcc8
-
-This masks the new gcc8 warning
-include/linux/regset.h:270:4: error: 'memcpy' offset [-527, -529] is out of the bounds [0, 16] of object 'vrsave' with type 'union <anonymous>'
-
-Signed-off-by: Khem Raj <raj.khem@gmail.com>
-Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
+# base patch: http://lists.openembedded.org/pipermail/openembedded-core/2018-June/151673.html
+#
+# From 8632f470f02c70d9501ae21f57740ea23c14773f Mon Sep 17 00:00:00 2001
+# From: Khem Raj <raj.khem@gmail.com>
+# Date: Fri, 4 May 2018 09:50:05 -0700
+# Subject: [PATCH 2/2] powerpc/ptrace: Disable array-bounds warning with gcc8
+#
+# This masks the new gcc8 warning
+# include/linux/regset.h:270:4: error: 'memcpy' offset [-527, -529] is out of the bounds [0, 16] of object 'vrsave' with type 'union <anonymous>'
+#
+# Signed-off-by: Khem Raj <raj.khem@gmail.com>
+# Signed-off-by: Bruce Ashfield <bruce.ashfield@windriver.com>
 ---
  arch/powerpc/kernel/Makefile | 1 +
  1 file changed, 1 insertion(+)
@@ -23,7 +25,4 @@ index 7fab5ab9edc2..601118b43545 100644
 +CFLAGS_ptrace.o		+= $(call cc-disable-warning, array-bounds)
  CFLAGS_syscalls.o	+= $(call cc-disable-warning, attribute-alias)
  
- subdir-ccflags-$(CONFIG_PPC_WERROR) := -Werror
--- 
-2.5.0
-
+ # Disable clang warning for using setjmp without setjmp.h header


### PR DESCRIPTION
The code in Makefile has been changed, update patches to avoid conflict.
