### PR TITLE
openssl: ptest: Do not change target file name

### DIFF
--- a/recipes-debian/openssl/openssl_debian.bb
+++ b/recipes-debian/openssl/openssl_debian.bb
@@ -173,8 +173,8 @@ do_install_ptest () {
 	cp -r ${S}/external ${B}/test ${S}/test ${B}/fuzz ${S}/util ${B}/util ${D}${PTEST_PATH}
 
 	# For test_shlibload
-	ln -s ${libdir}/libcrypto.so.1.1 ${D}${PTEST_PATH}/libcrypto.so
-	ln -s ${libdir}/libssl.so.1.1 ${D}${PTEST_PATH}/libssl.so
+	ln -s ${libdir}/libcrypto.so.1.1 ${D}${PTEST_PATH}/
+	ln -s ${libdir}/libssl.so.1.1 ${D}${PTEST_PATH}/
 
 	install -d ${D}${PTEST_PATH}/apps
 	ln -s ${bindir}/openssl ${D}${PTEST_PATH}/apps


### PR DESCRIPTION
OpenSSL's ptest failed by following errors.

```
test/recipes/90-test_shlibload.t ..
1..10
Failed to load libcrypto
../util/shlib_wrap.sh ./shlibloadtest -crypto_first ../libcrypto.so.1.1 ../libssl.so.1.1 /tmp/w5Gepyd2VU => 1
not ok 1 - running shlibloadtest -crypto_first /tmp/w5Gepyd2VU
not ok 2
Failed to load libssl
```

Test test/recipes/90-test_shlibload.t runs following command.
```
../util/shlib_wrap.sh ./shlibloadtest -crypto_first ../libcrypto.so.1.1 ../libssl.so.1.1 /tmp/w5Gepyd2VU => 1
```
This test uses libcrypto.so.1.1 and libssl.so.1.1 for tests which are in /usr/lib/openssl/ptest/ but
we have libcrypto.so and libssl.so in the directory not libcrypto.so.1.1 and libssl.so.1.1.
It seems it is the root cause of test failure.
Therefore in the do_install_ptest(), create symbolic links with same name.

This patch creates symbolic links as poky does.
[meta/recipes-connectivity/openssl/openssl_1.1.1b.bb](https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-connectivity/openssl/openssl_1.1.1b.bb?h=warrior#n170)

I have confirmed that all openssl tests  passed with this patch.

```
root@qemuarm64:~# ptest-runner -t 4000 openssl                                                                                                                                                        
START: ptest-runner                                                                                                                                                                                   
2019-08-16T03:43                                                                                                                                                                                      
BEGIN: /usr/lib/openssl/ptest                                                                                                                                                                         
PASS: test/recipes/01-test_abort.t                                                                                                                                                                    
PASS: test/recipes/01-test_sanity.t                                                                                                                                                                   
SKIP: test/recipes/01-test_symbol_presence.t (The case needs debug symbols then we just disable it)                                                                                                   
PASS: test/recipes/01-test_test.t                                                                                                                                                                     
PASS: test/recipes/02-test_errstr.t                                                                                                                                                                   
PASS: test/recipes/02-test_internal_ctype.t                                                                                                                                                           
PASS: test/recipes/02-test_lhash.t                                                                                                                                                                    
PASS: test/recipes/02-test_ordinals.t                                                                                                                                                                 
PASS: test/recipes/02-test_stack.t                                                                                                                                                                    
PASS: test/recipes/03-test_exdata.t                                                                                                                                                                   
PASS: test/recipes/03-test_internal_asn1.t                                                                                                                                                            
PASS: test/recipes/03-test_internal_chacha.t                                                                                                                                                          
PASS: test/recipes/03-test_internal_curve448.t                                                                                                                                                        
PASS: test/recipes/03-test_internal_ec.t                                                                                                                                                              
PASS: test/recipes/03-test_internal_mdc2.t                                                                                                                                                            
PASS: test/recipes/03-test_internal_modes.t                                                                                                                                                           
PASS: test/recipes/03-test_internal_poly1305.t                                                                                                                                                        
PASS: test/recipes/03-test_internal_siphash.t                                                                                                                                                         
PASS: test/recipes/03-test_internal_sm2.t                                                                                                                                                             
PASS: test/recipes/03-test_internal_sm4.t                                                                                                                                                             
PASS: test/recipes/03-test_internal_ssl_cert_table.t                                                                                                                                                  
PASS: test/recipes/03-test_internal_x509.t                                                                                                                                                            
PASS: test/recipes/03-test_ui.t 
PASS: test/recipes/04-test_asn1_decode.t                                                                                                                                                              
PASS: test/recipes/04-test_asn1_encode.t                                                                                                                                                              
PASS: test/recipes/04-test_asn1_string_table.t                                                                                                                                                        
PASS: test/recipes/04-test_bio_callback.t                                                                                                                                                             
PASS: test/recipes/04-test_bioprint.t                                                                                                                                                                 
PASS: test/recipes/04-test_err.t                                                                                                                                                                      
PASS: test/recipes/04-test_pem.t                                                                                                                                                                      
PASS: test/recipes/05-test_bf.t                                                                                                                                                                       
PASS: test/recipes/05-test_cast.t                                                                                                                                                                     
PASS: test/recipes/05-test_des.t                                                                                                                                                                      
PASS: test/recipes/05-test_hmac.t                                                                                                                                                                     
PASS: test/recipes/05-test_idea.t                                                                                                                                                                     
SKIP: test/recipes/05-test_md2.t (md2 is not supported by this OpenSSL build)
PASS: test/recipes/05-test_mdc2.t
PASS: test/recipes/05-test_rand.t
PASS: test/recipes/05-test_rc2.t
PASS: test/recipes/05-test_rc4.t
SKIP: test/recipes/05-test_rc5.t (rc5 is not supported by this OpenSSL build)
PASS: test/recipes/06-test-rdrand.t
PASS: test/recipes/10-test_bn.t
PASS: test/recipes/10-test_exp.t
PASS: test/recipes/15-test_dh.t
PASS: test/recipes/15-test_dsa.t
PASS: test/recipes/15-test_ec.t
PASS: test/recipes/15-test_ecdsa.t
PASS: test/recipes/15-test_ecparam.t
PASS: test/recipes/15-test_genrsa.t
PASS: test/recipes/15-test_mp_rsa.t
PASS: test/recipes/15-test_out_option.t
PASS: test/recipes/15-test_rsa.t
PASS: test/recipes/15-test_rsapss.t
PASS: test/recipes/20-test_enc.t
PASS: test/recipes/20-test_enc_more.t
PASS: test/recipes/20-test_passwd.t
PASS: test/recipes/25-test_crl.t
PASS: test/recipes/25-test_d2i.t
PASS: test/recipes/25-test_pkcs7.t
PASS: test/recipes/25-test_req.t
PASS: test/recipes/25-test_sid.t
PASS: test/recipes/25-test_verify.t
PASS: test/recipes/25-test_x509.t
PASS: test/recipes/30-test_afalg.t
PASS: test/recipes/30-test_engine.t
PASS: test/recipes/30-test_evp.t
PASS: test/recipes/30-test_evp_extra.t
PASS: test/recipes/30-test_pbelu.t
PASS: test/recipes/30-test_pkey_meth.t
PASS: test/recipes/30-test_pkey_meth_kdf.t
PASS: test/recipes/40-test_rehash.t
PASS: test/recipes/60-test_x509_check_cert_pkey.t
PASS: test/recipes/60-test_x509_dup_cert.t
PASS: test/recipes/60-test_x509_store.t
PASS: test/recipes/60-test_x509_time.t
PASS: test/recipes/70-test_asyncio.t
PASS: test/recipes/70-test_bad_dtls.t
PASS: test/recipes/70-test_clienthello.t
PASS: test/recipes/70-test_comp.t
PASS: test/recipes/70-test_key_share.t
PASS: test/recipes/70-test_packet.t
PASS: test/recipes/70-test_recordlen.t
PASS: test/recipes/70-test_renegotiation.t
PASS: test/recipes/70-test_servername.t
PASS: test/recipes/70-test_sslcbcpadding.t
PASS: test/recipes/70-test_sslcertstatus.t
PASS: test/recipes/70-test_sslextension.t
PASS: test/recipes/70-test_sslmessages.t
PASS: test/recipes/70-test_sslrecords.t
PASS: test/recipes/70-test_sslsessiontick.t
PASS: test/recipes/70-test_sslsigalgs.t
PASS: test/recipes/70-test_sslsignature.t
PASS: test/recipes/70-test_sslskewith0p.t
PASS: test/recipes/70-test_sslversions.t
PASS: test/recipes/70-test_sslvertol.t
PASS: test/recipes/70-test_tls13alerts.t
PASS: test/recipes/70-test_tls13cookie.t
PASS: test/recipes/70-test_tls13downgrade.t
PASS: test/recipes/70-test_tls13hrr.t
PASS: test/recipes/70-test_tls13kexmodes.t
PASS: test/recipes/70-test_tls13messages.t
PASS: test/recipes/70-test_tls13psk.t
PASS: test/recipes/70-test_tlsextms.t
PASS: test/recipes/70-test_verify_extra.t
PASS: test/recipes/70-test_wpacket.t
PASS: test/recipes/80-test_ca.t
PASS: test/recipes/80-test_cipherbytes.t
PASS: test/recipes/80-test_cipherlist.t
PASS: test/recipes/80-test_ciphername.t
PASS: test/recipes/80-test_cms.t
PASS: test/recipes/80-test_cmsapi.t
PASS: test/recipes/80-test_ct.t
PASS: test/recipes/80-test_dane.t
PASS: test/recipes/80-test_dtls.t
PASS: test/recipes/80-test_dtls_mtu.t
PASS: test/recipes/80-test_dtlsv1listen.t
PASS: test/recipes/80-test_ocsp.t
PASS: test/recipes/80-test_pkcs12.t
PASS: test/recipes/80-test_ssl_new.t
PASS: test/recipes/80-test_ssl_old.t
PASS: test/recipes/80-test_ssl_test_ctx.t
PASS: test/recipes/80-test_sslcorrupt.t
PASS: test/recipes/80-test_tsa.t
PASS: test/recipes/80-test_x509aux.t
PASS: test/recipes/90-test_asn1_time.t
PASS: test/recipes/90-test_async.t
PASS: test/recipes/90-test_bio_enc.t
PASS: test/recipes/90-test_bio_memleak.t
PASS: test/recipes/90-test_constant_time.t
PASS: test/recipes/90-test_fatalerr.t
PASS: test/recipes/90-test_gmdiff.t
SKIP: test/recipes/90-test_gost.t (No test GOST engine found)
PASS: test/recipes/90-test_ige.t
PASS: test/recipes/90-test_includes.t
PASS: test/recipes/90-test_memleak.t
SKIP: test/recipes/90-test_overhead.t (Only supported in no-shared builds)
PASS: test/recipes/90-test_secmem.t
PASS: test/recipes/90-test_shlibload.t
PASS: test/recipes/90-test_srp.t
PASS: test/recipes/90-test_sslapi.t
PASS: test/recipes/90-test_sslbuffers.t
PASS: test/recipes/90-test_store.t
PASS: test/recipes/90-test_sysdefault.t
PASS: test/recipes/90-test_threads.t
PASS: test/recipes/90-test_time_offset.t
PASS: test/recipes/90-test_tls13ccs.t
PASS: test/recipes/90-test_tls13encryption.t
PASS: test/recipes/90-test_tls13secrets.t
PASS: test/recipes/90-test_v3name.t
SKIP: test/recipes/95-test_external_boringssl.t (No external tests in this configuration)
SKIP: test/recipes/95-test_external_krb5.t (No external tests in this configuration)
SKIP: test/recipes/95-test_external_pyca.t (No external tests in this configuration)
PASS: test/recipes/99-test_ecstress.t
PASS: test/recipes/99-test_fuzz.t
All tests successful.
Files=155, Tests=1449, 1369 wallclock secs (33.01 usr  3.61 sys + 1001.99 cusr 282.51 csys = 1321.12 CPU)
Result: PASS
DURATION: 1371
END: /usr/lib/openssl/ptest
2019-08-16T04:06
STOP: ptest-runner
root@qemuarm64:~# 
```
