### PR TITLE
gawk: ptest: update do_install_ptest() recipe

### DIFF
--- a/recipes-debian/gawk/gawk_debian.bb
+++ b/recipes-debian/gawk/gawk_debian.bb
@@ -56,7 +56,7 @@ inherit ptest
 
 do_install_ptest() {
 	mkdir ${D}${PTEST_PATH}/test
-	for i in `grep -vE "@|^$|#|Gt-dummy" ${S}/test/Maketests |awk -F: '{print $1}'` Maketests; \
+	for i in `grep -vE "@|^$|#|Gt-dummy" ${S}/test/Maketests |awk -F: '{print $1}'` Maketests inclib.awk; \
 		do cp ${S}/test/$i* ${D}${PTEST_PATH}/test; \
 	done
 	sed -i -e 's|/usr/local/bin|${bindir}|g' \


### PR DESCRIPTION
When run ptest, "include" test is failed.
I found poky and meta-debian do_install_ptest() are bit differrent[1].
Therefore updated do_install_ptest() recipe like poky.
The gawk's ptest success with this patch.

1:https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/recipes-extended/gawk/gawk_4.2.1.bb?h=warrior&id=fdfdd899451674f1756f441fd0bf03a7b0f138aa