### PR TITLE
glibc: update way to remove empty /usr/share

### DIFF
--- a/recipes-debian/glibc/glibc_debian.bb
+++ b/recipes-debian/glibc/glibc_debian.bb
@@ -139,11 +139,15 @@ do_install_append() {
 
 require recipes-core/glibc/glibc-package.inc
 
-do_poststash_install_cleanup_append() {
-	# We don't want to ship an empty /usr/share
-	if [ -d ${D}${datadir} ]; then
-		rmdir --ignore-fail-on-non-empty ${D}${datadir}
-	fi
+stash_locale_sysroot_cleanup() {
+        stash_locale_cleanup ${SYSROOT_DESTDIR}
+        # We don't want to ship an empty /usr/share
+        rmdir --ignore-fail-on-non-empty ${SYSROOT_DESTDIR}${datadir}
+}
+stash_locale_package_cleanup() {
+        stash_locale_cleanup ${PKGD}
+        # We don't want to ship an empty /usr/share
+        rmdir --ignore-fail-on-non-empty ${PKGD}${datadir}
 }
 
 # for glibc-2.28


### PR DESCRIPTION
Follow-up for poky's commit b174d936e91902c3e2ab800856bb7bc492d096a0.

The commit removes `do_poststash_install_cleanup()` task. So the `_append()` does not remove empty /usr/share any more.