### PR TITLE
pseudo: Add checksum of license file

### DIFF
--- a/recipes-debian/pseudo/pseudo_debian.bb
+++ b/recipes-debian/pseudo/pseudo_debian.bb
@@ -4,6 +4,8 @@ inherit debian-package
 require recipes-debian/sources/pseudo.inc
 FILESPATH_append = ":${COREBASE}/meta/recipes-devtools/pseudo/files"
 
+LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
+
 SRC_URI += " \
            file://0001-configure-Prune-PIE-flags.patch \
            file://fallback-passwd \


### PR DESCRIPTION
LIC_FILES_CHKSUM was located in pseudo.inc in poky, so this recipe cannot build if the value was updated. This PR fixes it.