### PR TITLE
ipxe: build only for x86 or x86_64 target

### DIFF
--- a/recipes-debian/ipxe/ipxe_debian.bb
+++ b/recipes-debian/ipxe/ipxe_debian.bb
@@ -9,6 +9,7 @@ require recipes-debian/sources/ipxe.inc
 
 S = "${DEBIAN_UNPACK_DIR}/src"
 
+COMPATIBLE_HOST = '(x86_64|i.86).*-(linux|freebsd.*)'
 DEPENDS = "cdrtools-native xz-native syslinux"
 
 do_configure() {


### PR DESCRIPTION
When invoke 'bitbake world -c cleanall' for aarch64, then it fails as syslinux is not provided and ipxe depends on syslinux.