### PR TITLE
perl: re-add some dependent packages for ptest

### DIFF
--- a/recipes-debian/perl/perl_debian.bb
+++ b/recipes-debian/perl/perl_debian.bb
@@ -169,6 +169,9 @@ perl_package_preprocess () {
 
 require recipes-devtools/perl-sanity/perl-ptest.inc
 
+RDEPENDS_${PN}-ptest += " gcc binutils glibc-dev libgcc-dev linux-libc-headers-base-dev"
+INSANE_SKIP_${PN}-ptest += "dev-deps"
+
 FILES_${PN} = " \
     ${bindir}/perl ${bindir}/perl.real ${bindir}/perl${PV} ${libdir}/libperl.so* \
     ${libdir}/perl5/site_perl \


### PR DESCRIPTION
The packages were added by 7dedd80ff47de4ed88b637c32ed2b3aba1965c3f, and removed by c87f4cc5fd8fb87d99ebcd8094567f9df3b987d7.