### PR TITLE
tcpdump: bump the upstream version to 4.9.3-1~deb8u1

### DIFF
--- a/recipes-debian/tcpdump/tcpdump/add-ptest.patch
+++ b/recipes-debian/tcpdump/tcpdump/add-ptest.patch
@@ -1,20 +1,22 @@
-From 7b259580800e259d232229dc89f97058b56e2fe8 Mon Sep 17 00:00:00 2001
+From 8c9c728757f89ebe6c4019114b83a63c63596f69 Mon Sep 17 00:00:00 2001
 From: "Hongjun.Yang" <hongjun.yang@windriver.com>
-Date: Wed, 22 Oct 2014 10:02:48 +0800
+Date: Wed, 2 Oct 2019 16:57:06 -0400
 Subject: [PATCH] Add ptest for tcpdump
 
 Upstream-Status: Pending
 
 Signed-off-by: Hongjun.Yang <hongjun.yang@windriver.com>
+Signed-off-by: Peiran Hong <peiran.hong@windriver.com>
+
 ---
  Makefile.in | 10 +++++++++-
  1 file changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/Makefile.in b/Makefile.in
-index 8c35a45..4fb8ae6 100644
+index 3b589184..7b10e38c 100644
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -436,9 +435,17 @@ distclean:
+@@ -437,9 +437,17 @@ distclean:
  	    tests/failure-outputs.txt
  	rm -rf autom4te.cache tests/DIFF tests/NEW
  
@@ -22,17 +24,14 @@ index 8c35a45..4fb8ae6 100644
 +buildtest-TESTS: tcpdump
 +
 +runtest-PTEST:
- 	(cd tests && ./TESTrun.sh)
+	(mkdir -p tests && SRCDIR=`cd ${srcdir}; pwd` && export SRCDIR && $$SRCDIR/tests/TESTrun.sh )
  
 +install-ptest:
-+	cp -r tests			$(DESTDIR)
-+	cp -r config.h			$(DESTDIR)
-+	install -m 0755 Makefile 	$(DESTDIR)
-+	ln -sf /usr/sbin/tcpdump	$(DESTDIR)/tcpdump
++	cp -r tests                     $(DESTDIR)
++	cp -r config.h                  $(DESTDIR)
++	install -m 0755 Makefile        $(DESTDIR)
++	ln -sf /usr/sbin/tcpdump        $(DESTDIR)/tcpdump
 +
  extags: $(TAGFILES)
- 	ctags -wtd $(TAGFILES)
+ 	ctags $(TAGFILES)
  
--- 
-1.9.1
-

--- a/recipes-debian/tcpdump/tcpdump/avoid-absolute-path-when-searching-for-libdlpi.patch
+++ b/recipes-debian/tcpdump/tcpdump/avoid-absolute-path-when-searching-for-libdlpi.patch
@@ -1,0 +1,31 @@
+From 02085028cdaf075943c27ebc02bb6de0289ec1d3 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Wed, 2 Oct 2019 16:43:48 -0400
+Subject: [PATCH] avoid absolute path when searching for libdlpi
+
+Let the build environment control library search paths.
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+Signed-off-by: Peiran Hong <peiran.hong@windriver.com>
+---
+ configure.ac | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 3401a7a3..6a52485a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -528,7 +528,7 @@ don't.])
+ fi
+ 
+ # libdlpi is needed for Solaris 11 and later.
+-AC_CHECK_LIB(dlpi, dlpi_walk, LIBS="$LIBS -ldlpi" LDFLAGS="-L/lib $LDFLAGS", ,-L/lib)
++AC_CHECK_LIB(dlpi, dlpi_walk, LIBS="$LIBS -ldlpi")
+ 
+ dnl
+ dnl Check for "pcap_list_datalinks()", "pcap_set_datalink()",
+-- 
+2.17.1
+

--- a/recipes-debian/tcpdump/tcpdump/run-ptest
+++ b/recipes-debian/tcpdump/tcpdump/run-ptest
@@ -1,5 +1,5 @@
 #!/bin/sh
 make -k runtest-PTEST | sed -e '/: passed/ s/^/PASS: /g' \
-			-e '/: failed/ s/^/FAIL: /g' \
+			-e '/: TEST FAILED.*/ s/^/FAIL: /g' \
 			-e 's/: passed//g' \
-			-e 's/: failed//g'
+			-e 's/: TEST FAILED.*//g'

--- a/recipes-debian/tcpdump/tcpdump/unnecessary-to-check-libpcap.patch
+++ b/recipes-debian/tcpdump/tcpdump/unnecessary-to-check-libpcap.patch
@@ -1,6 +1,7 @@
-unnecessary to check libpcap
-
-Upstream-Status: Pending
+From dd023c133980fcc0cff5896e85377675e0571894 Mon Sep 17 00:00:00 2001
+From: Roy Li <rongqing.li@windriver.com>
+Date: Tue, 8 Jul 2014 13:20:47 +0800
+Subject: [PATCH] unnecessary to check libpcap
 
 since the check of libpcap did not consider the cross-compile, lead to the
 below error:
@@ -10,24 +11,30 @@ below error:
 In fact, the libpcap has been added into the tcpdump's DEPENDS, not need to
 check if libpcap existed.
 
-Signed-off-by: Roy Li <rongqing.li@windriver.com>
----
- configure.in |    2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+Upstream-Status: Inappropriate [OE specific]
 
-diff --git a/configure.in b/configure.in
-index 06fade1..9125de7 100644
---- a/configure.in
-+++ b/configure.in
-@@ -567,7 +567,7 @@ AC_SEARCH_LIBS(getrpcbynumber, nsl,
- dnl AC_CHECK_LIB(z, uncompress)
- dnl AC_CHECK_HEADERS(zlib.h)
+Signed-off-by: Roy Li <rongqing.li@windriver.com>
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+Signed-off-by: Peiran Hong <peiran.hong@windriver.com>
+---
+ configure.ac | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index 56e2a624..3401a7a3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -404,7 +404,9 @@ dnl Some platforms may need -lnsl for getrpcbynumber.
+ AC_SEARCH_LIBS(getrpcbynumber, nsl,
+     AC_DEFINE(HAVE_GETRPCBYNUMBER, 1, [define if you have getrpcbynumber()]))
  
 -AC_LBL_LIBPCAP(V_PCAPDEP, V_INCLS)
-+#AC_LBL_LIBPCAP(V_PCAPDEP, V_INCLS)
++# Simplified (more cross compile friendly) check for libpcap. All we really
++# need is to sanity check that libpcap is available and add -lpcap to LIBS.
++AC_CHECK_LIB(pcap, pcap_compile, LIBS="$LIBS -lpcap")
  
  #
  # Check for these after AC_LBL_LIBPCAP, so we link with the appropriate
 -- 
-1.7.9.5
+2.17.1
 

--- a/recipes-debian/tcpdump/tcpdump_debian.bb
+++ b/recipes-debian/tcpdump/tcpdump_debian.bb
@@ -1,44 +1,48 @@
 #
 # base recipe:
-#   http://cgit.openembedded.org/meta-openembedded/tree/meta-networking/recipes-support/tcpdump/tcpdump_4.6.1.bb
-# base commit: 90880880066981071f14a983c2da9f450f244192
+#   http://cgit.openembedded.org/meta-openembedded/tree/meta-networking/recipes-support/tcpdump/tcpdump_4.9.3.bb
+# base commit: a24acf94d48d635eca668ea34598c6e5c857e3f8
 #
 
 PR = "r0"
 
 inherit debian-package
-PV = "4.9.2"
+PV = "4.9.3"
 
 LICENSE = "BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1d4b0366557951c84a94fabe3529f867"
 
 DEPENDS = "libpcap libpcap-native"
 
+RDEPENDS_${PN}-ptest += " make perl \
+	perl-module-file-basename \
+	perl-module-posix \
+	perl-module-carp"
+
 SRC_URI += " \
     file://unnecessary-to-check-libpcap.patch \
+    file://avoid-absolute-path-when-searching-for-libdlpi.patch \
     file://add-ptest.patch \
     file://run-ptest \
 "
 
-export LIBS = " -lpcap"
-
 inherit autotools-brokensep ptest
-CACHED_CONFIGUREVARS = "ac_cv_linux_vers=${ac_cv_linux_vers=2}"
 
-PACKAGECONFIG ??= "openssl"
-PACKAGECONFIG[openssl] = "--with-crypto=yes,--without-crypto,openssl"
+PACKAGECONFIG ?= "openssl"
+
+PACKAGECONFIG[libcap-ng] = "--with-cap-ng,--without-cap-ng,libcap-ng"
+PACKAGECONFIG[openssl] = "--with-crypto,--without-crypto,openssl"
 PACKAGECONFIG[smi] = "--with-smi,--without-smi,libsmi"
+# Note: CVE-2018-10103 (SMB - partially fixed, but SMB printing disabled)
+PACKAGECONFIG[smb] = "--enable-smb,--disable-smb"
 
-EXTRA_AUTORECONF += " -I m4"
+EXTRA_AUTORECONF += "-I m4"
 
 do_configure_prepend() {
 	mkdir -p ${S}/m4
 	if [ -f aclocal.m4 ]; then
 		mv aclocal.m4 ${S}/m4
 	fi
-
-	# AC_CHECK_LIB(dlpi.. was looking to host /lib
-	sed -i 's:-L/lib::g' ./configure.in
 }
 
 do_compile_ptest() {


### PR DESCRIPTION
Import changes from meta-openembedded's
meta-networking/recipes-support/tcpdump/tcpdump_4.9.3.bb
(commit a24acf94d48d635eca668ea34598c6e5c857e3f8)

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>