### PR TITLE
meson: Handle strings in cross file args

### DIFF
--- a/recipes-debian/meson/meson.inc
+++ b/recipes-debian/meson/meson.inc
@@ -16,4 +16,5 @@ SRC_URI += " \
            file://disable-rpath-handling.patch \
            file://many-cross.patch \
            file://cross-libdir.patch \
+           file://0001-Handle-strings-in-cross-file-args.-Closes-4671.patch \
            "


### PR DESCRIPTION
Reuse the patch from layer "meta":
(0001-Handle-strings-in-cross-file-args.-Closes-4671.patch)
This allows <language>_args and <language>_link_args properties, e.g.,
c_link_args, in meson.cross to be specified as either a string or a
list.

(From meta:warrior: 8855a1ec4de0762038590ff06355af7ba8beea29)

Signed-off-by: Nguyen Van Hieu <hieu.nguyenvan@toshiba-tsdv.com>