### PR TITLE
linux-libc-headers, glibc: Add linux-libc-headers-dev to glibc-dev

### DIFF
--- a/recipes-debian/glibc/glibc_debian.bb
+++ b/recipes-debian/glibc/glibc_debian.bb
@@ -141,6 +141,9 @@ do_install_append() {
 
 require recipes-core/glibc/glibc-package.inc
 
+# This is a backport of poky's 38fce3d2fd998a67604f9492ab3a571f963c5df3
+RDEPENDS_${PN}-dev = "linux-libc-headers-dev"
+
 stash_locale_sysroot_cleanup() {
         stash_locale_cleanup ${SYSROOT_DESTDIR}
         # We don't want to ship an empty /usr/share

--- a/recipes-kernel/linux-libc-headers/linux-libc-headers-base_git.bb
+++ b/recipes-kernel/linux-libc-headers/linux-libc-headers-base_git.bb
@@ -5,3 +5,5 @@ require recipes-kernel/linux-libc-headers/linux-libc-headers.inc
 inherit linux-src
 
 PROVIDES += "linux-libc-headers"
+RPROVIDES_${PN}-dev += "linux-libc-headers-dev"
+RPROVIDES_${PN}-dbg += "linux-libc-headers-dbg"


### PR DESCRIPTION
Without this, the following code cannot be compiled with the SDK of core-image-minimal.
```
#include <errno.h>
#include <stdio.h>

int main(void)
{
        printf("errno = %d\n", errno);
        return 0;
}
```
Tested with
```
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby-tiny"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:023ff85a9ae94331926e923b346fd8a349881e63"
meta-debian          = "warrior:f396c5441b87530abe2d67d470a2894d341330ce"
```