### PR TITLE
Fix do_rootfs base-files pkg_postinst_${PN} is no longer supported.

### DIFF
--- a/recipes-debian/base-files/base-files_debian.bb
+++ b/recipes-debian/base-files/base-files_debian.bb
@@ -71,7 +71,7 @@ do_install() {
 	install -m 0644 ${WORKDIR}/shells ${D}${sysconfdir}/
 }
 
-pkg_postinst_${PN}() {
+pkg_postinst_ontarget_${PN} () {
 	for i in log/wtmp log/btmp log/lastlog run/utmp; do
 		test -f $D${localstatedir}/$i || echo -n > $D${localstatedir}/$i
 		chown root:utmp $D${localstatedir}/$i


### PR DESCRIPTION
```
poky        : warrior:c9a1a608f5146e5dcfebc8e566cb7f6388a3986f
meta-intel  : warrior:f45cc044a52cb73efabff334c1220604c02fbf1a
meta-debian : warrior:60d07df8cc8ae038c10f9733048389dd1792018f
```
Build
-----
1. Create `meta-debian/bsp/meta-intel` to add `conf/bblayers.conf.sample`.
   ```sh
   $ vi conf/bblayers.conf.sample
   ...
   BBLAYERS ?= " \
      ##OEROOT##/poky/meta \
      ##OEROOT##/poky/meta-poky \
      ##OEROOT##/layers/meta-intel \
      ##OEROOT##/layers/meta-debian \
        "
   ```

2. Setup build directory.
   ```sh
   $ export TEMPLATECONF=meta-debian/bsp/meta-intel/conf
   $ source ./poky/oe-init-build-env build-x86_64
   ```

2. Set `MACHINE` to `intel-corei7-64`.
   ```sh
   $ vi conf/local.conf
   ...
   MACHINE ??= "intel-corei7-64"
   LINUX_DEFCONFIG_intel-corei7-64 = "x86_64_defconfig"
   ...
   ```

4. Build `DISTRO` is set to default 'deby-tiny' `core-image-minimal` build (or 'deby'  `core-image-base` build)
   ```sh
   $ bitbake core-image-minimal
   ```

Problem
---------
Yocto bitake build FAILED with a messages : 
   ```sh
ERROR: core-image-base-1.0-r0 do_rootfs: Postinstall scriptlets of ['base-files'] have failed. If the intention is to defer them to first boot,
then please place them into pkg_postinst_ontarget_${PN} ().
Deferring to first boot via 'exit 1' is no longer supported.
   ```