### PR TITLE
openssl: Enable os option for with-rand-seed as well

### DIFF
--- a/recipes-debian/openssl/openssl_debian.bb
+++ b/recipes-debian/openssl/openssl_debian.bb
@@ -49,10 +49,10 @@ do_configure[cleandirs] = "${B}"
 EXTRA_OECONF_append_libc-musl = " no-async"
 EXTRA_OECONF_append_libc-musl_powerpc64 = " no-asm"
 
-# This prevents openssl from using getrandom() which is not available on older glibc versions
+# adding devrandom prevents openssl from using getrandom() which is not available on older glibc versions
 # (native versions can be built with newer glibc, but then relocated onto a system with older glibc)
-EXTRA_OECONF_class-native = "--with-rand-seed=devrandom"
-EXTRA_OECONF_class-nativesdk = "--with-rand-seed=devrandom"
+EXTRA_OECONF_class-native = "--with-rand-seed=os,devrandom"
+EXTRA_OECONF_class-nativesdk = "--with-rand-seed=os,devrandom"
 
 # Relying on hardcoded built-in paths causes openssl-native to not be relocateable from sstate.
 CFLAGS_append_class-native = " -DOPENSSLDIR=/not/builtin -DENGINESDIR=/not/builtin"


### PR DESCRIPTION
with openSSL 1.1.1d we start seeing errors like
```
Error Generating Key
139979727451584:error:2406C06E:random number generator:RAND_DRBG_instantiate:error retrieving entropy:../openssl-1.1.1d/crypto/rand/drbg_lib.c:342:
```
when using openssl from openssl-native on build hosts, this is due to
limiting the random seed to devrandom, to support older hosts, since the
option allows to have a comma separated list of methods to try, we can
try the default first and if that fails then fallback to devrandom, this
will ensure that it keeps working with build systems which dont support
getrandom()

(From OE-Core rev: 8b4edb8552b238680d8dcef565e830a8e28a223c)
(From Poky rev: 53b5654d6eebfbc1e290af3cfda7f0ed7b71f59e)

See also https://www.mail-archive.com/openembedded-core@lists.openembedded.org/msg127852.html.