### PR TITLE
python: add tk-lib as runtime dependency for python-tkinter

### DIFF
--- a/recipes-debian/python/python_debian.bb
+++ b/recipes-debian/python/python_debian.bb
@@ -187,7 +187,7 @@ RDEPENDS_${PN}-modules += "${PN}-misc"
 
 # ptest
 RDEPENDS_${PN}-ptest = "${PN}-modules ${PN}-tests unzip tzdata-europe coreutils sed"
-RDEPENDS_${PN}-tkinter += "${@bb.utils.contains('PACKAGECONFIG', 'tk', 'tk', '', d)}"
+RDEPENDS_${PN}-tkinter += "${@bb.utils.contains('PACKAGECONFIG', 'tk', 'tk tk-lib', '', d)}"
 # catch manpage
 PACKAGES += "${PN}-man"
 FILES_${PN}-man = "${datadir}/man"


### PR DESCRIPTION
From Poky rev: [cd8a048b620b04dcaa7969d70684bcad243ccc58](https://git.yoctoproject.org/cgit/cgit.cgi/poky/commit/?id=cd8a048b620b04dcaa7969d70684bcad243ccc58)