### PR TITLE
libpcap: Add a patch to fix build race condition

### DIFF
--- a/recipes-debian/libpcap/libpcap/0001-Fix-the-dependencies-for-the-object-files-of-scanner.patch
+++ b/recipes-debian/libpcap/libpcap/0001-Fix-the-dependencies-for-the-object-files-of-scanner.patch
@@ -1,0 +1,34 @@
+From 54cd27dbf27d1c448a91314251502d0a8d2ab296 Mon Sep 17 00:00:00 2001
+From: Joerg Mayer <jmayer@loplof.de>
+Date: Sun, 6 May 2018 08:18:39 +0200
+Subject: [PATCH] Fix the dependencies for the object files of scanner.c and
+ grammar.c
+
+---
+ CMakeLists.txt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fbc452e7..6fc61080 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1758,7 +1758,7 @@ add_custom_command(
+ #
+ set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/scanner.c PROPERTIES
+     GENERATED TRUE
+-    OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/scanner.h
++    OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/grammar.h
+ )
+ 
+ #
+@@ -1797,6 +1797,7 @@ add_custom_command(
+ #
+ set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/grammar.c PROPERTIES
+     GENERATED TRUE
++    OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/scanner.h
+ )
+ 
+ #
+-- 
+2.17.1
+

--- a/recipes-debian/libpcap/libpcap_debian.bb
+++ b/recipes-debian/libpcap/libpcap_debian.bb
@@ -19,6 +19,7 @@ require recipes-debian/sources/libpcap.inc
 SRC_URI += "file://0001-pcap-usb-linux.c-add-missing-limits.h-for-musl-syste.patch \
             file://fix-lds-path.diff \
             file://add-fPIC.diff \            
+            file://0001-Fix-the-dependencies-for-the-object-files-of-scanner.patch \
             "
 
 inherit autotools binconfig-disabled pkgconfig bluetooth


### PR DESCRIPTION
Sometimes I face the following error:
```
../libpcap-1.8.1/gencode.c:77:10: fatal error: grammar.h: No such file or directory
 #include "grammar.h"
          ^~~~~~~~~~~
compilation terminated.
Makefile:96: recipe for target 'gencode_pic.o' failed
```

My guess is that it will be solved by https://github.com/the-tcpdump-group/libpcap/commit/54cd27dbf27d1c448a91314251502d0a8d2ab296