### PR TITLE
doc: Add notice about not to reuse CVE patches

### DIFF
--- a/doc/3.development/3.1.create_recipe.md
+++ b/doc/3.development/3.1.create_recipe.md
@@ -60,6 +60,9 @@ but there are some rules need to be concerned.
    FILESPATH_append = ":${COREBASE}/meta/recipes-devtools/sample/sample"
    SRC_URI += "file://sample.patch"
    ```
+   *Note: Security fixes should be managed by Debian in source package,
+   so don't reuse patches, which relate to CVE or security bugs, in meta-debian.
+   It is better to wait for Debian maintainers apply patch into source code.*
 
 ### Configuration and packages split
 * This version of meta-debian aims to be compatible with


### PR DESCRIPTION
Security fixes should be handled by Debian source package.
It is better to wait for Debian maintainers decide to apply the fix
or not.
This can avoid conflict between recipe's patches and Debian source package.
