### PR TITLE
doc/5.limitation.md: Add information about PACKAGECONFIG variation support

### DIFF
--- a/doc/5.limitation.md
+++ b/doc/5.limitation.md
@@ -9,3 +9,10 @@ _meta/lib/oe/package_manager.py_.
 Poky has its own [prelink-cross](http://git.yoctoproject.org/cgit.cgi/prelink-cross) package.
 Debian 10 prelink (0.0.20131005-1+b10) does not support changing root directory
 which is required by _meta/classes/image-prelink.bbclass_.
+
+
+# PACKAGECONFIG variation support
+
+For now, to keep meta-debian minimal and reduce effort of maintenance,
+meta-debian only provides recipes to support PACKAGECONFIG features which are enabled by default.
+More recipes may be added in future if there are any requests.


### PR DESCRIPTION
For now, to keep meta-debian minimal and reduce effort of maintenance,
meta-debian only provides recipes to support PACKAGECONFIG features which are enabled by default.
More recipes may be added in future if there are requests.