### PR TITLE
libbsd: Remove the empty DEBIAN_QUILT_PATCHES

### DIFF
--- a/recipes-debian/libbsd/libbsd_debian.bb
+++ b/recipes-debian/libbsd/libbsd_debian.bb
@@ -17,9 +17,6 @@ PR = "r0"
 inherit debian-package
 PV = "0.7.0"
 
-# source format is 3.0 but there is no patch
-DEBIAN_QUILT_PATCHES = ""
-
 LICENSE = "BSD-4-Clause & MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=f1530ea92aeaa1c5e2547cfd43905d8c"
 SECTION = "libs"


### PR DESCRIPTION
libbsd-0.7.0-2+deb8u1 has added new debian/patches,
so remove the empty DEBIAN_QUILT_PATCHES.

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>