### PR TITLE
Add ptest for acl

### DIFF
--- a/recipes-debian/attr/acl/run-ptest
+++ b/recipes-debian/attr/acl/run-ptest
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# This script is used to run acl test suites
+# This script is based on poky's ptest for acl.
+#umask 077
+
+testcase_dir=$(realpath ./test)
+EXT3_IMAGE=ext3.img
+EXT3_MOUNT_POINT=/mnt/ext3
+
+trap 'rm -f ${EXT3_IMAGE}' EXIT
+
+dd if=/dev/zero of=${EXT3_IMAGE} bs=1M count=1
+if [ "$?" -eq 0 ]; then
+	echo "PASS: dump ext3.img"
+else
+	echo "FAIL: dump ext3.img"
+	exit 1
+fi
+
+mkfs.ext3 -F ${EXT3_IMAGE}
+if [ "$?" -eq 0 ]; then
+	echo "PASS: mkfs.ext3 -F ext3.img"
+else
+	echo "FAIL: mkfs.ext3 -F ext3.img"
+	exit 1
+fi
+
+if [ -d $EXT3_MOUNT_POINT ]; then
+	echo "mount point exist"
+else
+	mkdir -p $EXT3_MOUNT_POINT
+fi
+
+mount -o loop,rw,acl  ${EXT3_IMAGE} $EXT3_MOUNT_POINT
+if [ "$?" -eq 0 ]; then
+	echo "PASS: mount ext3.img"
+else
+	echo "FAIL: mount ext3.img"
+	exit 1
+fi
+
+cp -rf ./test/ $EXT3_MOUNT_POINT
+
+cd $EXT3_MOUNT_POINT/test/
+
+if sed -e 's!^bin:x:2:$!bin:x:2:daemon!' < /etc/group > gtmp; then
+	if cp /etc/group group.orig; then
+		cp gtmp /etc/group
+		for i in $(find ${testcase_dir} -name "*.test"); do
+			${testcase_dir}/run ${i} | sed \
+				-e 's|^\[.*\] \(.*\) -- ok$|PASS: \1|' \
+				-e 's|^\[.*\] \(.*\) -- failed|FAIL: \1|'
+			done
+		cp group.orig /etc/group
+	else
+		echo "FAIL: couldn't save original group file."
+		exit 1
+	fi
+else
+	echo "FAIL: couldn't create modified group file."
+	exit 1
+fi
+
+cd -
+umount $EXT3_MOUNT_POINT
+rm -rf $EXT3_MOUNT_POINT
+rm $EXT3_IMAGE

--- a/recipes-debian/attr/acl_debian.bb
+++ b/recipes-debian/attr/acl_debian.bb
@@ -13,9 +13,30 @@ DEPENDS = "attr"
 inherit debian-package
 require recipes-debian/sources/acl.inc
 
-inherit autotools gettext
+SRC_URI += "file://run-ptest"
+
+inherit autotools gettext ptest
 
 BBCLASSEXTEND = "native nativesdk"
 
 PACKAGES =+ "lib${BPN}"
 FILES_lib${BPN} = "${libdir}/lib*${SOLIBS}"
+
+do_install_ptest() {
+	install -Dm755 ${WORKDIR}/run-ptest ${D}${PTEST_PATH}
+	cp -r ${S}/test ${D}${PTEST_PATH}
+	rm ${D}${PTEST_PATH}/test/runwrapper
+}
+
+RDEPENDS_${PN}-ptest = "\
+	acl \
+	perl-module-cwd \
+	perl-module-file-basename \
+	perl-module-file-path \
+	perl-module-filehandle \
+	perl-module-file-spec \
+	perl-module-constant \
+	perl-module-getopt-std \
+	perl-module-posix \
+	e2fsprogs-mke2fs \
+"


### PR DESCRIPTION
I took a mistake, so I re-created this PR. You can refer the previous one from [here](https://github.com/meta-debian/meta-debian/pull/221).

This ptest is created based on poky's ptest for acl (070ea45b6c).

You can test this PR as follows:

local.conf:

```
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_ROOTFS_EXTRA_SPACE = "20480"
```

Run:

```shell
$ ptest-runner acl
```

I have confirmed that the following test case will be failed:

```
FAIL: $ getfacl --omit-header f
FAIL: $ getfacl --omit-header f
FAIL: $ getfacl --omit-header f
FAIL: $ getfacl --omit-header d
FAIL: $ getfacl --omit-header d/d
FAIL: $ getfacl --omit-header d/l
FAIL: $ getfacl --omit-header d/d
FAIL: $ getfacl --omit-header d/d
FAIL: $ getfacl --omit-header d
FAIL: $ getfacl --omit-header d
FAIL: $ getfacl --omit-header d
FAIL: $ getfacl --omit-header d
FAIL: $ setfacl -m u:domain\\12345:rw- d/f
FAIL: $ getfacl --omit-header d/f
FAIL: $ setfacl -m u:domain\\user:rw- d/f
FAIL: $ getfacl --omit-header d/f
FAIL: $ setfacl -dm group:loooooooooooooooooooooooonggroup:rwx d
FAIL: $ getfacl -cde d
FAIL: $ cat f
FAIL: $ echo daemon4 >> f
FAIL: $ cat f
FAIL: $ : < f
FAIL: $ find test/sub2 | sort | xargs ls -dl | awk '{print $1,$8}'
FAIL: $ find test/sub2 | sort | xargs ls -dl | awk '{print $1,$8}'
FAIL: $ find test/sub2 | sort | xargs ls -dl | awk '{print $1,$8}'
FAIL: $ cat test/blah
FAIL: $ cat test/blah
FAIL: $ cat test/blah
FAIL: $ cat test/blah
```

I assume that these test case failed due to `/etc/groups`. debian's groups and the groups which acl's test expected are different. However, I think it can be ignored.