### PR TITLE
glibc: Fix build error when set DEBUG_BUILD="1"

### DIFF
--- a/recipes-debian/glibc/glibc_debian.bb
+++ b/recipes-debian/glibc/glibc_debian.bb
@@ -87,6 +87,7 @@ EXTRA_OECONF = "--enable-kernel=${OLDEST_KERNEL} \
                 --enable-stack-protector=strong \
                 --enable-stackguard-randomization \
                 --enable-nscd \
+                ${@bb.utils.contains_any('SELECTED_OPTIMIZATION', '-O0 -Og', '--disable-werror', '', d)} \
                 ${GLIBCPIE} \
                 ${GLIBC_EXTRA_OECONF}"
 


### PR DESCRIPTION
When set DEBUG_BUILD="1" to local.conf, got following build error.

```
| make[2]: ***
[/home/masami/metadebian/build/tmp/work/aarch64-deby-linux/glibc/2.28-r0/build-aarch64-deby-linux/posix/regex.o]
Error 1
| make[2]: *** Waiting for unfinished jobs....
| In file included from regex.c:72:
| regexec.c: In function 'check_node_accept_bytes':
| regexec.c:3833:29: error: 'extra' may be used uninitialized in this
function [-Werror=maybe-uninitialized]
|         const unsigned char *coll_sym = extra + cset->coll_syms[i];
|                              ^~~~~~~~
| cc1: all warnings being treated as errors
| ../o-iterator.mk:9: recipe for target
'/home/masami/metadebian/build/tmp/work/aarch64-deby-linux/glibc/2.28-r0/build-aarch64-deby-linux/posix/regex.os'
failed
| make[2]: ***
[/home/masami/metadebian/build/tmp/work/aarch64-deby-linux/glibc/2.28-r0/build-aarch64-deby-linux/posix/regex.os]
Error 1
```

glibc's compile option contains -Werror so that causes build error.
However, poky disables -Werror when enable debug option, so that
poky is able to build glibc with debug option.

Use SELECTED_OPTIMIZATION variable to change compile option by
DEBUG_BUILD is defined or not.