### PR TITLE
diffutils: Add perl to ptest environment

### DIFF
--- a/recipes-debian/diffutils/diffutils_debian.bb
+++ b/recipes-debian/diffutils/diffutils_debian.bb
@@ -15,7 +15,7 @@ acpaths = "-I ./m4"
 
 inherit ptest
 
-RDEPENDS_${PN}-ptest += "make"
+RDEPENDS_${PN}-ptest += "make perl"
 
 do_install_ptest() {
 	t=${D}${PTEST_PATH}


### PR DESCRIPTION
Without perl, got following error.

```
============================================================================
make[1]: *** [Makefile:1554: test-suite.log] Error 1
make[1]: Leaving directory '/usr/lib/diffutils/ptest/tests'
make: *** [Makefile:1662: check-TESTS] Error 2
make: Leaving directory '/usr/lib/diffutils/ptest/tests'

ERROR: Exit status is 512
DURATION: 20
```

Add pers to RDEPENDS_${PN}-ptest, it works fine.

```
============================================================================
make[1]: Leaving directory '/usr/lib/diffutils/ptest/tests'
make: Leaving directory '/usr/lib/diffutils/ptest/tests'
DURATION: 21
END: /usr/lib/diffutils/ptest
2020-06-08T00:24
STOP: ptest-runner
```