### PR TITLE
[morty] gcc*: Stop separating PRs for gcc* recipes

### DIFF
--- a/recipes-debian/gcc/gcc-cross-canadian_debian.bb
+++ b/recipes-debian/gcc/gcc-cross-canadian_debian.bb
@@ -3,8 +3,6 @@
 # base branch: daisy
 #
 
-PR = "r0"
-
 require gcc-4.9.inc
 require gcc-shared-source.inc
 

--- a/recipes-debian/gcc/gcc-cross-initial_debian.bb
+++ b/recipes-debian/gcc/gcc-cross-initial_debian.bb
@@ -3,8 +3,6 @@
 # base branch: daisy
 #
 
-PR = "r0"
-
 require gcc-cross_${PV}.bb
 
 DEPENDS = "virtual/${TARGET_PREFIX}binutils ${NATIVEDEPS}"

--- a/recipes-debian/gcc/gcc-cross_debian.bb
+++ b/recipes-debian/gcc/gcc-cross_debian.bb
@@ -6,8 +6,6 @@
 require gcc-4.9.inc
 require gcc-shared-source.inc
 
-PR = "r0"
-
 inherit cross
 
 INHIBIT_DEFAULT_DEPS = "1"

--- a/recipes-debian/gcc/gcc-crosssdk-initial_debian.bb
+++ b/recipes-debian/gcc/gcc-crosssdk-initial_debian.bb
@@ -3,8 +3,6 @@
 # base branch: daisy
 #
 
-PR = "r0"
-
 require gcc-cross-initial_${PV}.bb
 
 inherit crosssdk

--- a/recipes-debian/gcc/gcc-crosssdk_debian.bb
+++ b/recipes-debian/gcc/gcc-crosssdk_debian.bb
@@ -3,7 +3,6 @@
 # base branch: daisy
 #
 
-PR = "r0"
 require gcc-cross_${PV}.bb
 
 inherit crosssdk

--- a/recipes-debian/gcc/gcc-runtime_debian.bb
+++ b/recipes-debian/gcc/gcc-runtime_debian.bb
@@ -3,8 +3,6 @@
 # base branch: daisy
 #
 
-PR = "r0"
-
 require gcc-4.9.inc
 require gcc-shared-source.inc
 require gcc-configure-common.inc

--- a/recipes-debian/gcc/gcc-sanitizers_debian.bb
+++ b/recipes-debian/gcc/gcc-sanitizers_debian.bb
@@ -3,7 +3,6 @@
 # base branch: daisy
 #
 PV = "4.9.2"
-PR = "r0"
 
 require gcc-4.9.inc
 require gcc-shared-source.inc

--- a/recipes-debian/gcc/gcc_debian.bb
+++ b/recipes-debian/gcc/gcc_debian.bb
@@ -3,8 +3,6 @@
 # base branch: daisy
 #
 
-PR = "r0"
-
 require gcc-4.9.inc
 require gcc-shared-source.inc
 # Building with thumb enabled on armv4t fails with

--- a/recipes-debian/gcc/libgcc_debian.bb
+++ b/recipes-debian/gcc/libgcc_debian.bb
@@ -3,8 +3,6 @@
 # base branch: master
 #
 
-PR = "r0"
-
 require libgcc-common.inc
 
 DEPENDS = "virtual/${TARGET_PREFIX}gcc virtual/${TARGET_PREFIX}g++"


### PR DESCRIPTION
gcc* use same shared source code. It will fail to find gcc source if PRs are not same.