### PR TITLE
dosfstools: Remove the empty DEBIAN_QUILT_PATCHES

### DIFF
--- a/recipes-debian/dosfstools/dosfstools_debian.bb
+++ b/recipes-debian/dosfstools/dosfstools_debian.bb
@@ -9,9 +9,6 @@ PV = "3.0.27"
 LICENSE = "GPLv3+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504"
 
-# source format is 3.0 (quilt) but there is no debian patch
-DEBIAN_QUILT_PATCHES = ""
-
 do_install() {
 	oe_runmake "DESTDIR=${D}" "PREFIX=${prefix}" "SBINDIR=${base_sbindir}" install
 }


### PR DESCRIPTION
dosfstools_3.0.27-1+deb8u1 has added new debian/patches,
so remove the empty DEBIAN_QUILT_PATCHES.

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>