### PR TITLE
base-files: fix build failure with multilib

### DIFF
--- a/recipes-debian/base-files/base-files_debian.bb
+++ b/recipes-debian/base-files/base-files_debian.bb
@@ -19,6 +19,8 @@ OSNAME = "GNU/Linux"
 do_install() {
 	( test -f ${S}/debian/base-files.dirs && \
 	    cd ${D} && install -d $(cat ${S}/debian/base-files.dirs))
+	#in case of ${libdir} != "lib" (ex. multilib)
+	install -d ${D}${libdir}
 
 	rm -rf ${D}${localstatedir}/run ${D}${localstatedir}/lock
 	ln -sf /run ${D}${localstatedir}/run


### PR DESCRIPTION
Fix do_install failure ("cannot create .../image/usr/lib64/os-release:
Directory nonexistent") with non-standard ${libdir} value.

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>