### PR TITLE
nativesdk-bison: Add to nativesdk-packagegroup-sdk-host and set BISON…

### DIFF
--- a/recipes-debian/bison/bison_debian.bb
+++ b/recipes-debian/bison/bison_debian.bb
@@ -50,5 +50,9 @@ do_install_append_class-native() {
 	create_wrapper ${D}/${bindir}/bison \
 		BISON_PKGDATADIR=${STAGING_DATADIR_NATIVE}/bison
 }
+do_install_append_class-nativesdk() {
+	create_wrapper ${D}/${bindir}/bison \
+		BISON_PKGDATADIR=${datadir}/bison
+}
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
…_PKGDATADIR

bison is needed when building kernel. Add it to nativesdk-packagegroup-sdk-host
and set BISON_PKGDATADIR for bison to use its components.

(From poky fe86a79fc33a4a9229e62f543ccefa4722aa2546)

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>