### PR TITLE
base-files: fix pkg_postinst failure

### DIFF
--- a/recipes-debian/base-files/base-files_debian.bb
+++ b/recipes-debian/base-files/base-files_debian.bb
@@ -76,7 +76,8 @@ do_install() {
 pkg_postinst_${PN}() {
 	for i in log/wtmp log/btmp log/lastlog run/utmp; do
 		test -f $D${localstatedir}/$i || echo -n > $D${localstatedir}/$i
-		chown root:utmp $D${localstatedir}/$i
+		# use 43 instead of 'utmp' to avoid failure on package_ipk
+		chown root:43 $D${localstatedir}/$i
 		chmod 664 $D${localstatedir}/$i
 	done
 	chmod 660 $D${localstatedir}/log/btmp


### PR DESCRIPTION
Workaround for following error with package_ipk:
  WARNING: core-image-minimal-1.0-r0 do_populate_sdk: base-files.postinst returned 1, marking as unpacked only, configuration required on target.
  ERROR: core-image-minimal-1.0-r0 do_populate_sdk: Postinstall scriptlets of ['base-files'] have failed. If the intention is to defer them to first boot,
  then please place them into pkg_postinst_ontarget_${PN} ().

The error message in log.do_populate_sdk is:
  chown: invalid group: 'root:utmp'

This error can happen when running 'bitbake -c populate_sdk core-image-minimal'
before running 'bitbake core-image-minimal'.

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>