### PR TITLE
syslog-ng: add syslog-ng-mod-journal package

### DIFF
--- a/recipes-debian/syslog-ng/syslog-ng_debian.bb
+++ b/recipes-debian/syslog-ng/syslog-ng_debian.bb
@@ -25,6 +25,10 @@ DEPENDS = " \
     bison-native autoconf-archive-native \
 "
 
+PACKAGES =+ "${PN}-mod-journal"
+FILES_${PN}-mod-journal = "${libdir}/syslog-ng/libsdjournal.so"
+CONFIG_${PN}-mod-journal = "--with-systemd-journal"
+
 inherit autotools gettext systemd pkgconfig update-rc.d
 
 EXTRA_OECONF = " \
@@ -40,6 +44,7 @@ EXTRA_OECONF = " \
     --disable-python \
     --disable-java --disable-java-modules \
     --with-ivykis=system \
+    ${CONFIG_${PN}-mod-journal} \
     ${CONFIG_TLS} \
 "
 

--- a/recipes-debian/syslog-ng/syslog-ng_debian.bb
+++ b/recipes-debian/syslog-ng/syslog-ng_debian.bb
@@ -25,10 +25,6 @@ DEPENDS = " \
     bison-native autoconf-archive-native \
 "
 
-PACKAGES =+ "${PN}-mod-journal"
-FILES_${PN}-mod-journal = "${libdir}/syslog-ng/libsdjournal.so"
-CONFIG_${PN}-mod-journal = "--with-systemd-journal"
-
 inherit autotools gettext systemd pkgconfig update-rc.d
 
 EXTRA_OECONF = " \
@@ -44,7 +40,7 @@ EXTRA_OECONF = " \
     --disable-python \
     --disable-java --disable-java-modules \
     --with-ivykis=system \
-    ${CONFIG_${PN}-mod-journal} \
+    --with-systemd-journal \
     ${CONFIG_TLS} \
 "
 


### PR DESCRIPTION
Added missing binary package syslog-ng-mod-journal to the PACKAGES,
so that it can be included in the target image by specifiying in local.conf

 IMAGE_INSTALL_append = " syslog-ng-mod-journal"

Signed-off-by: venkata pyla <venkata.pyla@toshiba-tsip.com>