### PR TITLE
util-linux: add tar for ptest

### DIFF
--- a/recipes-debian/util-linux/util-linux_debian.bb
+++ b/recipes-debian/util-linux/util-linux_debian.bb
@@ -29,3 +29,5 @@ SRC_URI += "file://configure-sbindir.patch \
 "
 
 PACKAGECONFIG_class-nativesdk ?= "${@bb.utils.filter('DISTRO_FEATURES', 'pam', d)}"
+
+RDEPENDS_${PN}-ptest += "tar"


### PR DESCRIPTION
util-linux's ptest use xz option to unarchive tar file but busybox's tar doesn't
support it. Add tar package for run ptest.

```
SKIP:       losetup: losetup-loop                   (missing scsi_debug module (dry-run))
tar: unrecognized option '--xz'
BusyBox v1.30.1 (2020-09-10 04:12:26 UTC) multi-call binary.
Usage: tar c|x|t [-ZzJjahmvokO] [-f TARFILE] [-C DIR] [-T FILE] [-X FILE] [FILE]...
ls: cannot access '/usr/lib/util-linux/ptest/tests/output/lsblk/dumps/simple-lvm/*.cols': No such file or directory
tar: unrecognized option '--xz'
BusyBox v1.30.1 (2020-09-10 04:12:26 UTC) multi-call binary.
Usage: tar c|x|t [-ZzJjahmvokO] [-f TARFILE] [-C DIR] [-T FILE] [-X FILE] [FILE]...
ls: cannot access '/usr/lib/util-linux/ptest/tests/output/lsblk/dumps/simple-nvme/*.cols': No such file or directory
```