### PR TITLE
Add lacking license file name to LIC_FILES_CHKSUM.

### DIFF
--- a/recipes-debian/attr/attr_debian.bb
+++ b/recipes-debian/attr/attr_debian.bb
@@ -8,6 +8,7 @@ LICENSE = "LGPLv2.1+ & GPLv2+"
 LICENSE_${PN} = "GPLv2+"
 LICENSE_lib${BPN} = "LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://doc/COPYING;md5=2d0aa14b3fce4694e4f615e30186335f \
+                    file://doc/COPYING.LGPL;md5=b8d31f339300bc239d73461d68e77b9c \
                     file://tools/attr.c;endline=17;md5=be0403261f0847e5f43ed5b08d19593c \
                     file://libattr/libattr.c;endline=17;md5=7970f77049f8fa1199fff62a7ab724fb"
 

--- a/recipes-debian/kmod/kmod.inc
+++ b/recipes-debian/kmod/kmod.inc
@@ -11,6 +11,7 @@ SECTION = "base"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
                     file://libkmod/COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                    file://tools/COPYING;md5=751419260aa954499f7abaabaa882bbe \
                    "
 
 inherit debian-package


### PR DESCRIPTION
LIC_FILES_CHKSUM in kmod and attr recipe lack a license file name which should be included.