### PR TITLE
syslog-ng-mod-journal: add mod-journal binary package

### DIFF
--- a/recipes-debian/syslog-ng/syslog-ng_debian.bb
+++ b/recipes-debian/syslog-ng/syslog-ng_debian.bb
@@ -25,6 +25,9 @@ DEPENDS = " \
     bison-native autoconf-archive-native \
 "
 
+PACKAGES =+ "${PN}-mod-journal"
+FILES_${PN}-mod-journal = "${libdir}/syslog-ng/libsdjournal.so"
+
 inherit autotools gettext systemd pkgconfig update-rc.d
 
 EXTRA_OECONF = " \
@@ -40,6 +43,7 @@ EXTRA_OECONF = " \
     --disable-python \
     --disable-java --disable-java-modules \
     --with-ivykis=system \
+    --with-systemd-journal=auto \
     ${CONFIG_TLS} \
 "
 


### PR DESCRIPTION
Add syslog-ng-mod-journal library as an optional package
and can be included in the target image by specifying in local.conf
 `IMAGE_INSTALL_append = " syslog-ng-mod-journal"`

Signed-off-by: venkata pyla <venkata.pyla@toshiba-tsip.com>