### PR TITLE
libxml: Fix libxml2-utils packaging issue

### DIFF
--- a/recipes-debian/libxml/libxml2_debian.bb
+++ b/recipes-debian/libxml/libxml2_debian.bb
@@ -62,7 +62,8 @@ python populate_packages_prepend () {
         d.setVar('PKG_libxml2', '${MLPREFIX}libxml2')
 }
 
-PACKAGES += "${PN}-utils ${PN}-python"
+PACKAGE_BEFORE_PN += "${PN}-utils"
+PACKAGES += "${PN}-python"
 
 FILES_${PN}-staticdev += "${PYTHON_SITEPACKAGES_DIR}/*.a"
 FILES_${PN}-dev += "${libdir}/xml2Conf.sh ${libdir}/cmake/*"


### PR DESCRIPTION
libxml2 package contains xmlcatalog and xmllint commands, which should be provided by libxml2-utils package.

```
masami@ubuntu1804:~/metadebian/build$ ls tmp/work/aarch64-deby-linux/libxml2/2.9.4-r0/packages-split/libxml2/usr/
./  ../  bin/  lib/
masami@ubuntu1804:~/metadebian/build$ ls tmp/work/aarch64-deby-linux/libxml2/2.9.4-r0/packages-split/libxml2/usr/bin/
./  ../  xmlcatalog*  xmllint*
masami@ubuntu1804:~/metadebian/build$ ls tmp/work/aarch64-deby-linux/libxml2/2.9.4-r0/packages-split/libxml2-utils/
./  ../
```

So, empty libxml2-utils package causes following error when add libxml2-utils to rootfs.

```
ERROR: core-image-minimal-1.0-r0 do_rootfs: Unable to install packages.
Command
'/home/masami/metadebian/build/tmp/work/qemuarm64-deby-linux/core-image-minimal/1.0-r0/recipe-sysroot-native/usr/bin/apt-get
install --force-yes --allow-unauthenticated libxml2-utils
packagegroup-core-boot run-postinsts' returned 100:
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libxml2-utils
```

Use PACKAGE_BEFORE_PN to create libxml2-utils package before create libxml2 as poky does.