### PR TITLE
google-authenticator: Fix sdk build issue

### DIFF
--- a/recipes-debian/google-authenticator/libpam-google-authenticator_debian.bb
+++ b/recipes-debian/google-authenticator/libpam-google-authenticator_debian.bb
@@ -20,8 +20,7 @@ EXTRA_OECONF += "--libdir=${base_libdir}"
 
 REQUIRED_DISTRO_FEATURES = "pam"
 
-PACKAGES =+ "libpam-${PN}"
-FILES_libpam-${PN} = "${base_libdir}/security/pam_google_authenticator.so \
-		      ${bindir}/*"
+FILES_${PN} = "${base_libdir}/security/pam_google_authenticator.so \
+	       ${bindir}/*"
 
-RDEPENDS_libpam-${PN}  = "libpam"
+RDEPENDS_${PN}  = "libpam"


### PR DESCRIPTION
When set IMAGE_INSTALL_append += "libpam-google-authenticator" to conf/local.conf then build sdk, got following build error.

```
The following packages have unmet dependencies:
 google-authenticator-dev : Depends: google-authenticator (=
20170702-r0) but it is not installable
E: Unable to correct problems, you have held broken packages.
```

This root cause is recipe creates google-authenticator package which is empty and not installable. 
It'd be nice to rename recipe file name to stop create empty package.