### PR TITLE
debian-cve-check.bbclass: Fix multiple download

### DIFF
--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -19,10 +19,7 @@ python debian_cve_check () {
         bb.note("%s dosen't use debian source" % d.getVar("BPN"))
         return
 
-    json_url = "https://security-tracker.debian.org/tracker/data/json"
     json_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True),"dst.json")
-
-    update_dst(json_url, json_path)
     dst_data = load_json(json_path)
 
     # get package name from DEBIAN_SRC_URI
@@ -44,7 +41,7 @@ python debian_cve_check () {
 
 do_cve_check[prefuncs] += "debian_cve_check"
 
-def update_dst(url, dist_path):
+python update_dst () {
     """
     Update debian security tracker json file.
     """
@@ -52,6 +49,8 @@ def update_dst(url, dist_path):
     import shutil
     from datetime import datetime, date
 
+    json_url = "https://security-tracker.debian.org/tracker/data/json"
+    dist_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True),"dst.json")
     dist_dir = os.path.dirname(dist_path)
 
     if not os.path.isdir(dist_dir):
@@ -62,9 +61,12 @@ def update_dst(url, dist_path):
         if timestamp.date() == date.today():
             return
 
-    with urllib.request.urlopen(url) as response, open(dist_path, 'wb') as f:
+    with urllib.request.urlopen(json_url) as response, open(dist_path, 'wb') as f:
         shutil.copyfileobj(response, f)
     bb.debug(2, "DST database updated")
+}
+
+do_populate_cve_db[postfuncs] += "update_dst"
 
 def load_json(path):
     """


### PR DESCRIPTION
debian-cve-check include update process of CVE information from Debian Security Tracker.
There is timestamp check to prevent multiple download.
However, if the task execute at the same time in parallel, pass timestamp checking and 
json file is downloaded multiple times.

To fix this, move json update process after do_populate_cve_db.