### PR TITLE
openssl: Fix QA issue host-user-contaminated

### DIFF
--- a/recipes-debian/openssl/openssl_debian.bb
+++ b/recipes-debian/openssl/openssl_debian.bb
@@ -137,10 +137,13 @@ do_install () {
 	# Create SSL structure for packages such as ca-certificates which
 	# contain hard-coded paths to /etc/ssl. Debian does the same.
 	install -d ${D}${sysconfdir}/ssl
-	mv ${D}${libdir}/ssl-1.1/certs \
-	   ${D}${libdir}/ssl-1.1/private \
-	   ${D}${libdir}/ssl-1.1/openssl.cnf \
-	   ${D}${sysconfdir}/ssl/
+	cp -r --no-preserve=ownership ${D}/${libdir}/ssl-1.1/certs ${D}${sysconfdir}/ssl/
+	cp -r --no-preserve=ownership ${D}/${libdir}/ssl-1.1/private ${D}${sysconfdir}/ssl/
+	install ${D}${libdir}/ssl-1.1/openssl.cnf ${D}${sysconfdir}/ssl/
+
+	rm -rf ${D}${libdir}/ssl-1.1/certs
+	rm -rf ${D}${libdir}/ssl-1.1/private
+	rm -f ${D}${libdir}/ssl-1.1/openssl.cnf
 
 	# Although absolute symlinks would be OK for the target, they become
 	# invalid if native or nativesdk are relocated from sstate.


### PR DESCRIPTION
When use mv command in do_package(), it preserves UID and GID.
According to yocto manual[1], it recommends to use install command or
cp with --no-preserve option to not preserve UID/GID. So to fix host-user-contaminated issue[2], use install and cp command instead of mv.

When mv command is used,  uid 1000 owned ./etc/ssl/certs,  ./etc/ssl/private/, and ./etc/ssl/openssl.cnf.

```
masami@debian:~/meta-debian/build$ dpkg-deb -c tmp/work/aarch64-deby-linux/openssl/1.1.1d-r0/deploy-debs/aarch64/openssl-conf_1.1.1d-r0_arm64.deb 
drwxrwxrwx root/root         0 2021-04-02 09:00 ./
drwxr-xr-x root/root         0 2021-04-02 09:00 ./etc/
drwxr-xr-x root/root         0 2021-04-02 09:00 ./etc/ssl/
-rw-r--r-- 1000/1000     11118 2021-04-02 09:00 ./etc/ssl/openssl.cnf
masami@debian:~/meta-debian/build$ dpkg-deb -c tmp/work/aarch64-deby-linux/openssl/1.1.1d-r0/deploy-debs/aarch64/openssl_1.1.1d-r0_arm64.deb 
drwxrwxrwx root/root         0 2021-04-02 09:00 ./
drwxr-xr-x root/root         0 2021-04-02 09:00 ./etc/
drwxr-xr-x root/root         0 2021-04-02 09:00 ./etc/ssl/
drwxr-xr-x 1000/1000         0 2021-04-02 09:00 ./etc/ssl/certs/
drwxr-xr-x 1000/1000         0 2021-04-02 09:00 ./etc/ssl/private/
drwxr-xr-x root/root         0 2021-04-02 09:00 ./usr/
drwxr-xr-x root/root         0 2021-04-02 09:00 ./usr/lib/
drwxr-xr-x root/root         0 2021-04-02 09:00 ./usr/lib/ssl-1.1/
-rw-r--r-- root/root       412 2021-04-02 09:00 ./usr/lib/ssl-1.1/ct_log_list.cnf
-rw-r--r-- root/root       412 2021-04-02 09:00 ./usr/lib/ssl-1.1/ct_log_list.cnf.dist
-rw-r--r-- root/root     11118 2021-04-02 09:00 ./usr/lib/ssl-1.1/openssl.cnf.dist
lrwxrwxrwx root/root         0 2021-04-02 09:00 ./usr/lib/ssl-1.1/certs -> ../../../etc/ssl/certs
lrwxrwxrwx root/root         0 2021-04-02 09:00 ./usr/lib/ssl-1.1/openssl.cnf -> ../../../etc/ssl/openssl.cnf
lrwxrwxrwx root/root         0 2021-04-02 09:00 ./usr/lib/ssl-1.1/private -> ../../../etc/ssl/private
```

When use install and cp with --no-preserve option,  root owned /etc/ssl/certs,  ./etc/ssl/private/, and ./etc/ssl/openssl.cnf.

```
masami@debian:~/meta-debian/build$ dpkg-deb -c tmp/work/aarch64-deby-linux/openssl/1.1.1d-r0/deploy-debs/aarch64/openssl-conf_1.1.1d-r0_arm64.deb 
drwxrwxrwx root/root         0 2021-04-02 10:29 ./
drwxr-xr-x root/root         0 2021-04-02 10:29 ./etc/
drwxr-xr-x root/root         0 2021-04-02 10:29 ./etc/ssl/
-rwxr-xr-x root/root     11118 2021-04-02 10:29 ./etc/ssl/openssl.cnf
masami@debian:~/meta-debian/build$ dpkg-deb -c tmp/work/aarch64-deby-linux/openssl/1.1.1d-r0/deploy-debs/aarch64/openssl_1.1.1d-r0_arm64.deb 
drwxrwxrwx root/root         0 2021-04-02 10:29 ./
drwxr-xr-x root/root         0 2021-04-02 10:29 ./etc/
drwxr-xr-x root/root         0 2021-04-02 10:29 ./etc/ssl/
drwxr-xr-x root/root         0 2021-04-02 10:29 ./etc/ssl/certs/
drwxr-xr-x root/root         0 2021-04-02 10:29 ./etc/ssl/private/
drwxr-xr-x root/root         0 2021-04-02 10:29 ./usr/
drwxr-xr-x root/root         0 2021-04-02 10:29 ./usr/lib/
drwxr-xr-x root/root         0 2021-04-02 10:29 ./usr/lib/ssl-1.1/
-rw-r--r-- root/root       412 2021-04-02 10:29 ./usr/lib/ssl-1.1/ct_log_list.cnf
-rw-r--r-- root/root       412 2021-04-02 10:29 ./usr/lib/ssl-1.1/ct_log_list.cnf.dist
-rw-r--r-- root/root     11118 2021-04-02 10:29 ./usr/lib/ssl-1.1/openssl.cnf.dist
lrwxrwxrwx root/root         0 2021-04-02 10:29 ./usr/lib/ssl-1.1/certs -> ../../../etc/ssl/certs
lrwxrwxrwx root/root         0 2021-04-02 10:29 ./usr/lib/ssl-1.1/openssl.cnf -> ../../../etc/ssl/openssl.cnf
lrwxrwxrwx root/root         0 2021-04-02 10:29 ./usr/lib/ssl-1.1/private -> ../../../etc/ssl/private
```

1: https://docs.yoctoproject.org/ref-manual/tasks.html#do-install
2: https://github.com/meta-debian/meta-debian/issues/275

