### PR TITLE
libbsd: Fix libbsd build error

### DIFF
--- a/recipes-debian/libbsd/libbsd_debian.bb
+++ b/recipes-debian/libbsd/libbsd_debian.bb
@@ -8,9 +8,6 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b552602fda69e34c753d26de383f33c5"
 inherit debian-package
 require recipes-debian/sources/libbsd.inc
 
-# There is no debian/patches
-DEBIAN_QUILT_PATCHES = ""
-
 inherit autotools pkgconfig
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This PR fix following error.

```
ERROR: libbsd-0.9.1-r0 do_debian_patch: DEBIAN_QUILT_PATCHES is null, but /home/masami/metadebian/build/tmp/work/aarch64-deby-linux/libbsd/0.9.1-r0/libbsd-0.9.1/debian/patches/series exists
ERROR: libbsd-0.9.1-r0 do_debian_patch: Please consider to redefine DEBIAN_QUILT_PATCHES
ERROR: libbsd-0.9.1-r0 do_debian_patch: Function failed: do_debian_patch (log file is located at /home/masami/metadebian/build/tmp/work/aarch64-deby-linux/libbsd/0.9.1-r0/temp/log.do_debian_patch.1062)
ERROR: Logfile of failure stored in: /home/masami/metadebian/build/tmp/work/aarch64-deby-linux/libbsd/0.9.1-r0/temp/log.do_debian_patch.1062
ERROR: Task (/home/masami/metadebian/poky/meta-debian/recipes-debian/libbsd/libbsd_debian.bb:do_debian_patch) failed with exit code '1'
```

New libbsd package contains [CVE 2019 20367.patch](https://sources.debian.org/patches/libbsd/0.9.1-2+deb10u1/) so it needs to remove ``` DEBIAN_QUILT_PATCHES = ''' ``` line.
