### PR TITLE
bsdmainutils: Add missing dependency on base-passwd

### DIFF
--- a/recipes-debian/bsdmainutils/bsdmainutils_debian.bb
+++ b/recipes-debian/bsdmainutils/bsdmainutils_debian.bb
@@ -16,7 +16,7 @@ PV = "9.0.6"
 LICENSE="BSD-4-Clause"
 LIC_FILES_CHKSUM="file://usr.bin/hexdump/hexdump.h;endline=35;md5=148f6a2793c64631604a03a5d41a2cdc"
 
-DEPENDS = "libhdate-native ncurses"
+DEPENDS = "libhdate-native ncurses base-passwd"
 
 DEBIAN_PATCH_TYPE = "quilt"
 


### PR DESCRIPTION
Hi, 
The do_install wil fail if missing group "tty":
 | chown root:tty /tmp/work/i586-deby-linux/bsdmainutils/9.0.6-r0/image/usr/bin/bsd-write
 | chown: invalid group: ‘root:tty’

should be add dependency on base-passwd package