### PR TITLE
imake/lndir: remove rdepends on "xproto"

### DIFF
--- a/recipes-debian/xorg-util/imake_debian.bb
+++ b/recipes-debian/xorg-util/imake_debian.bb
@@ -13,4 +13,4 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b9c6cfb044c6d0ff899eaafe4c729367"
 
 DEPENDS = "util-macros xproto xorg-cf-files"
 
-RDEPENDS_${PN} = "perl xproto"
+RDEPENDS_${PN} = "perl"

--- a/recipes-debian/xorg-util/lndir_debian.bb
+++ b/recipes-debian/xorg-util/lndir_debian.bb
@@ -7,5 +7,3 @@ PR = "${INC_PR}.0"
 LIC_FILES_CHKSUM = "file://COPYING;md5=28f22421a52f2e70ef04c9ce398fa28e"
 
 DEPENDS = "util-macros xproto"
-
-RDEPENDS_${PN} = "xproto"


### PR DESCRIPTION
The "imake" and "lndir" do not require to install "xproto" package
(follow the debian/control)
