### PR TITLE
recipes: disable binconfig scripts using binconfig-disabled.bbclass

### DIFF
--- a/recipes-debian/apache2/apache2.inc
+++ b/recipes-debian/apache2/apache2.inc
@@ -13,6 +13,8 @@ PV = "2.4.10"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=dbff5a2b542fa58854455bf1a0b94b83"
 
+SRC_URI += "file://configure-use-pkg-config-for-PCRE-detection.patch"
+
 inherit autotools pkgconfig perlnative
 
 # Correct installation and library path.

--- a/recipes-debian/apache2/files/configure-use-pkg-config-for-PCRE-detection.patch
+++ b/recipes-debian/apache2/files/configure-use-pkg-config-for-PCRE-detection.patch
@@ -1,0 +1,47 @@
+configure: use pkg-config for PCRE detection
+
+---
+ configure.in | 27 +++++----------------------
+ 1 file changed, 5 insertions(+), 22 deletions(-)
+
+diff --git a/configure.in b/configure.in
+index 864d7c7..da4138e 100644
+--- a/configure.in
++++ b/configure.in
+@@ -215,28 +215,11 @@ fi
+ AC_ARG_WITH(pcre,
+ APACHE_HELP_STRING(--with-pcre=PATH,Use external PCRE library))
+ 
+-AC_PATH_PROG(PCRE_CONFIG, pcre-config, false)
+-if test -d "$with_pcre" && test -x "$with_pcre/bin/pcre-config"; then
+-   PCRE_CONFIG=$with_pcre/bin/pcre-config
+-elif test -x "$with_pcre"; then
+-   PCRE_CONFIG=$with_pcre
+-fi
+-
+-if test "$PCRE_CONFIG" != "false"; then
+-  if $PCRE_CONFIG --version >/dev/null 2>&1; then :; else
+-    AC_MSG_ERROR([Did not find pcre-config script at $PCRE_CONFIG])
+-  fi
+-  case `$PCRE_CONFIG --version` in
+-  [[1-5].*])
+-    AC_MSG_ERROR([Need at least pcre version 6.0])
+-    ;;
+-  esac
+-  AC_MSG_NOTICE([Using external PCRE library from $PCRE_CONFIG])
+-  APR_ADDTO(PCRE_INCLUDES, [`$PCRE_CONFIG --cflags`])
+-  APR_ADDTO(PCRE_LIBS, [`$PCRE_CONFIG --libs`])
+-else
+-  AC_MSG_ERROR([pcre-config for libpcre not found. PCRE is required and available from http://pcre.org/])
+-fi
++PKG_CHECK_MODULES([PCRE], [libpcre], [
++  AC_DEFINE([HAVE_PCRE], [1], [Define if you have PCRE library])
++], [
++  AC_MSG_ERROR([$PCRE_PKG_ERRORS])
++])
+ APACHE_SUBST(PCRE_LIBS)
+ 
+ AC_MSG_NOTICE([])
+-- 
+1.9.3
+

--- a/recipes-debian/directfb/directfb_debian.bb
+++ b/recipes-debian/directfb/directfb_debian.bb
@@ -12,9 +12,12 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=dcf3c825659e82539645da41a7908589"
 
 DEPENDS_class-target = "${PN}-native"
 
-SRC_URI += "file://configure-remove-host-path.patch"
+SRC_URI += "file://configure-remove-host-path.patch \
+            file://Use-pkg-config-to-find-libpng.patch"
 
-inherit autotools pkgconfig lib_package
+BINCONFIG = "${bindir}/directfb-config"
+
+inherit autotools pkgconfig lib_package binconfig-disabled
 
 EXTRA_OECONF = " \
     --with-gfxdrivers=all \

--- a/recipes-debian/directfb/files/Use-pkg-config-to-find-libpng.patch
+++ b/recipes-debian/directfb/files/Use-pkg-config-to-find-libpng.patch
@@ -1,0 +1,15 @@
+Use pkg-config to find libpng.
+
+diff --git a/configure.in b/configure.in
+index 91b769d..739c0de 100644
+--- a/configure.in
++++ b/configure.in
+@@ -733,7 +733,7 @@ if test "$enable_png" = "yes"; then
+ *** libpng-config not found ])
+   else
+       PNG=yes
+-      LIBPNG=`$LIBPNG_CONFIG --libs`
++      LIBPNG=`pkg-config --libs libpng`
+   fi
+ 
+   dnl Test for libpng

--- a/recipes-debian/fontforge/files/configure-use-pkg-config-for-freetype-detection.patch
+++ b/recipes-debian/fontforge/files/configure-use-pkg-config-for-freetype-detection.patch
@@ -1,0 +1,20 @@
+configure: use pkg-config for freetype detection
+
+diff --git a/configure.in b/configure.in
+index e433eb0..77172ab 100644
+--- a/configure.in
++++ b/configure.in
+@@ -353,10 +353,10 @@ AC_CHECK_FUNC(tzset,:,AC_DEFINE(_NO_TZSET))
+ dnl Is there a better way to add a directory to the include path?
+ 
+ FreeType2_IncRoot=
+-if sh -c "freetype-config --prefix" >/dev/null 2>&1 ; then
+- FreeType2_IncRoot=`freetype-config --prefix`
++if sh -c "pkg-config --variable=prefix freetype2 >/dev/null 2>&1" ; then
++ FreeType2_IncRoot=`pkg-config --variable=prefix freetype2 | cut -d '"' -f2`
+  AC_CHECK_FILE($FreeType2_IncRoot/include/freetype2,CFLAGS="$CFLAGS -I$FreeType2_IncRoot/include/freetype2/",FreeType2_IncRoot=)
+- ft_flags=`freetype-config --cflags`
++ ft_flags=`pkg-config --cflags freetype2`
+  CFLAGS="$CFLAGS $ft_flags"
+ fi
+ 

--- a/recipes-debian/fontforge/fontforge-native_debian.bb
+++ b/recipes-debian/fontforge/fontforge-native_debian.bb
@@ -25,6 +25,7 @@ DEPENDS = "cairo-native freetype-native giflib-native libjpeg-turbo-native \
 SRC_URI += " \
     file://python_c-missing-semicolon.patch \
     file://fix-package-check-for-libxml2.patch \
+    file://configure-use-pkg-config-for-freetype-detection.patch \
 "
 
 inherit autotools-brokensep pkgconfig pythonnative native

--- a/recipes-debian/freetype/freetype_debian.bb
+++ b/recipes-debian/freetype/freetype_debian.bb
@@ -22,7 +22,9 @@ file://docs/FTL.TXT;md5=d479e83797f699fe873b38dadd0fcd4c \
 file://docs/GPLv2.TXT;md5=8ef380476f642c20ebf40fecb0add2ec \
 "
 
-inherit autotools-brokensep pkgconfig binconfig multilib_header
+BINCONFIG = "${bindir}/freetype-config"
+
+inherit autotools-brokensep pkgconfig binconfig-disabled multilib_header
 
 LIBTOOL = "${S}/builds/unix/${HOST_SYS}-libtool"
 EXTRA_OEMAKE = "'LIBTOOL=${LIBTOOL}'"

--- a/recipes-debian/libgcrypt/files/add-pkgconfig-support.patch
+++ b/recipes-debian/libgcrypt/files/add-pkgconfig-support.patch
@@ -1,22 +1,36 @@
-Upstream-Status: Inappropriate [distribution]
+Add and use pkg-config for libgcrypt instead of -config scripts.
 
-Index: libgcrypt-1.2.4/configure.ac
-===================================================================
---- libgcrypt-1.2.4.orig/configure.ac	2008-03-19 22:14:50.000000000 +0000
-+++ libgcrypt-1.2.4/configure.ac	2008-03-19 22:14:58.000000000 +0000
-@@ -807,6 +807,7 @@
+Upstream-Status: Denied [upstream have indicated they don't want a pkg-config dependency]
+
+RP 2014/5/22
+
+Rebase to 1.7.0
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ configure.ac        |  1 +
+ src/libgcrypt.m4    | 71 +++--------------------------------------------------
+ src/libgcrypt.pc.in | 33 +++++++++++++++++++++++++
+ 3 files changed, 38 insertions(+), 67 deletions(-)
+ create mode 100644 src/libgcrypt.pc.in
+
+diff --git a/configure.ac b/configure.ac
+index f683e21..566e1c8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -2314,6 +2314,7 @@ random/Makefile
  doc/Makefile
  src/Makefile
  src/gcrypt.h
 +src/libgcrypt.pc
  src/libgcrypt-config
+ src/versioninfo.rc
  tests/Makefile
- w32-dll/Makefile
-Index: libgcrypt-1.2.4/src/libgcrypt.pc.in
-===================================================================
---- /dev/null	1970-01-01 00:00:00.000000000 +0000
-+++ libgcrypt-1.2.4/src/libgcrypt.pc.in	2008-03-19 22:14:58.000000000 +0000
-@@ -0,0 +1,32 @@
+diff --git a/src/libgcrypt.pc.in b/src/libgcrypt.pc.in
+new file mode 100644
+index 0000000..2fc8f53
+--- /dev/null
++++ b/src/libgcrypt.pc.in
+@@ -0,0 +1,33 @@
 +# Process this file with autoconf to produce a pkg-config metadata file.
 +# Copyright (C) 2002, 2003, 2004, 2005, 2006 Free Software Foundation
 +# Author: Simon Josefsson
@@ -36,6 +50,7 @@ Index: libgcrypt-1.2.4/src/libgcrypt.pc.in
 +
 +# API info
 +api_version=@LIBGCRYPT_CONFIG_API_VERSION@
++host=@LIBGCRYPT_CONFIG_HOST@
 +
 +# Misc information.
 +symmetric_ciphers=@LIBGCRYPT_CIPHERS@
@@ -49,3 +64,98 @@ Index: libgcrypt-1.2.4/src/libgcrypt.pc.in
 +Libs: -L${libdir} -lgcrypt
 +Libs.private: -L${libdir} -lgpg-error
 +Cflags: -I${includedir} 
+-- 
+2.8.1
+diff --git a/src/libgcrypt.m4 b/src/libgcrypt.m4
+index 6cf482f..e72358c 100644
+--- a/src/libgcrypt.m4
++++ b/src/libgcrypt.m4
+@@ -22,17 +22,6 @@ dnl with a changed API.
+ dnl
+ AC_DEFUN([AM_PATH_LIBGCRYPT],
+ [ AC_REQUIRE([AC_CANONICAL_HOST])
+-  AC_ARG_WITH(libgcrypt-prefix,
+-            AC_HELP_STRING([--with-libgcrypt-prefix=PFX],
+-                           [prefix where LIBGCRYPT is installed (optional)]),
+-     libgcrypt_config_prefix="$withval", libgcrypt_config_prefix="")
+-  if test x$libgcrypt_config_prefix != x ; then
+-     if test x${LIBGCRYPT_CONFIG+set} != xset ; then
+-        LIBGCRYPT_CONFIG=$libgcrypt_config_prefix/bin/libgcrypt-config
+-     fi
+-  fi
+-
+-  AC_PATH_TOOL(LIBGCRYPT_CONFIG, libgcrypt-config, no)
+   tmp=ifelse([$1], ,1:1.2.0,$1)
+   if echo "$tmp" | grep ':' >/dev/null 2>/dev/null ; then
+      req_libgcrypt_api=`echo "$tmp"     | sed 's/\(.*\):\(.*\)/\1/'`
+@@ -42,38 +31,8 @@ AC_DEFUN([AM_PATH_LIBGCRYPT],
+      min_libgcrypt_version="$tmp"
+   fi
+ 
+-  AC_MSG_CHECKING(for LIBGCRYPT - version >= $min_libgcrypt_version)
+-  ok=no
+-  if test "$LIBGCRYPT_CONFIG" != "no" ; then
+-    req_major=`echo $min_libgcrypt_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\1/'`
+-    req_minor=`echo $min_libgcrypt_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
+-    req_micro=`echo $min_libgcrypt_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
+-    libgcrypt_config_version=`$LIBGCRYPT_CONFIG --version`
+-    major=`echo $libgcrypt_config_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
+-    minor=`echo $libgcrypt_config_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\2/'`
+-    micro=`echo $libgcrypt_config_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\3/'`
+-    if test "$major" -gt "$req_major"; then
+-        ok=yes
+-    else
+-        if test "$major" -eq "$req_major"; then
+-            if test "$minor" -gt "$req_minor"; then
+-               ok=yes
+-            else
+-               if test "$minor" -eq "$req_minor"; then
+-                   if test "$micro" -ge "$req_micro"; then
+-                     ok=yes
+-                   fi
+-               fi
+-            fi
+-        fi
+-    fi
+-  fi
++  PKG_CHECK_MODULES(LIBGCRYPT, [libgcrypt >= $min_libgcrypt_version], [ok=yes], [ok=no])
++
+   if test $ok = yes; then
+     AC_MSG_RESULT([yes ($libgcrypt_config_version)])
+   else
+@@ -83,7 +42,7 @@ AC_DEFUN([AM_PATH_LIBGCRYPT],
+      # If we have a recent libgcrypt, we should also check that the
+      # API is compatible
+      if test "$req_libgcrypt_api" -gt 0 ; then
+-        tmp=`$LIBGCRYPT_CONFIG --api-version 2>/dev/null || echo 0`
++        tmp=`$PKG_CONFIG --variable=api_version libgcrypt`
+         if test "$tmp" -gt 0 ; then
+            AC_MSG_CHECKING([LIBGCRYPT API version])
+            if test "$req_libgcrypt_api" -eq "$tmp" ; then
+@@ -96,10 +55,8 @@ AC_DEFUN([AM_PATH_LIBGCRYPT],
+      fi
+   fi
+   if test $ok = yes; then
+-    LIBGCRYPT_CFLAGS=`$LIBGCRYPT_CONFIG --cflags`
+-    LIBGCRYPT_LIBS=`$LIBGCRYPT_CONFIG --libs`
+     ifelse([$2], , :, [$2])
+-    libgcrypt_config_host=`$LIBGCRYPT_CONFIG --host 2>/dev/null || echo none`
++    libgcrypt_config_host=`$PKG_CONFIG --variable=host libgcrypt`
+     if test x"$libgcrypt_config_host" != xnone ; then
+       if test x"$libgcrypt_config_host" != x"$host" ; then
+   AC_MSG_WARN([[
+@@ -113,8 +70,6 @@ AC_DEFUN([AM_PATH_LIBGCRYPT],
+       fi
+     fi
+   else
+-    LIBGCRYPT_CFLAGS=""
+-    LIBGCRYPT_LIBS=""
+     ifelse([$3], , :, [$3])
+   fi
+   AC_SUBST(LIBGCRYPT_CFLAGS)

--- a/recipes-debian/libgcrypt/libgcrypt_debian.bb
+++ b/recipes-debian/libgcrypt/libgcrypt_debian.bb
@@ -8,7 +8,9 @@ SUMMARY = "General purpose cryptographic library based on the code from GnuPG"
 HOMEPAGE = "http://directory.fsf.org/project/libgcrypt/"
 BUGTRACKER = "https://bugs.g10code.com/gnupg/index"
 
-inherit debian-package autotools-brokensep binconfig pkgconfig
+BINCONFIG = "${bindir}/libgcrypt-config"
+
+inherit debian-package autotools-brokensep binconfig-disabled pkgconfig
 PV = "1.6.3"
 
 PR = "r3"
@@ -42,6 +44,11 @@ EXTRA_OECONF = " \
 # 	| ./.libs/libgcrypt.so: undefined reference to `_gcry_mpih_sub_n'
 # 	| ./.libs/libgcrypt.so: undefined reference to `_gcry_mpih_rshift'
 EXTRA_OECONF += "--disable-asm"
+
+do_configure_prepend () {
+	# Else this could be used in preference to the one in aclocal-copy
+	rm -f ${S}/m4/gpg-error.m4
+}
 
 # libgcrypt.pc is added locally and thus installed here
 do_install_append() {

--- a/recipes-debian/libgpg-error/files/pkgconfig.patch
+++ b/recipes-debian/libgpg-error/files/pkgconfig.patch
@@ -1,0 +1,149 @@
+
+#
+# Patch managed by http://www.mn-logistik.de/unsupported/pxa250/patcher
+#
+
+Upstream-Status: Pending
+
+Index: libgpg-error-1.17/configure.ac
+===================================================================
+--- libgpg-error-1.17.orig/configure.ac
++++ libgpg-error-1.17/configure.ac
+@@ -529,6 +529,7 @@ AC_CONFIG_FILES([src/Makefile tests/Make
+ AC_CONFIG_FILES([lang/Makefile lang/cl/Makefile lang/cl/gpg-error.asd])
+ AC_CONFIG_FILES([src/versioninfo.rc])
+ AC_CONFIG_FILES([src/gpg-error-config], [chmod +x src/gpg-error-config])
++AC_CONFIG_FILES([src/gpg-error.pc])
+ 
+ AC_OUTPUT
+ 
+diff --git a/src/Makefile.am b/src/Makefile.am
+index c4fd057..b20d418 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -77,13 +77,15 @@ nodist_include_HEADERS = gpg-error.h
+ bin_SCRIPTS = gpg-error-config
+ m4datadir = $(datadir)/aclocal
+ m4data_DATA = gpg-error.m4
++pkgconfigdir = $(libdir)/pkgconfig
++pkgconfig_DATA = gpg-error.pc
+ 
+ EXTRA_DIST = mkstrtable.awk err-sources.h.in err-codes.h.in \
+ 	mkerrnos.awk errnos.in README \
+ 	mkerrcodes.awk mkerrcodes1.awk mkerrcodes2.awk mkerrcodes.c \
+ 	mkheader.c gpg-error.h.in mkw32errmap.c w32-add.h w32ce-add.h \
+ 	err-sources.h err-codes.h gpg-error-config.in gpg-error.m4 \
+-	gpg-error.vers gpg-error.def.in versioninfo.rc.in \
++	gpg-error.vers gpg-error.def.in versioninfo.rc.in gpg-error.pc \
+ 	$(lock_obj_pub)
+ 
+ BUILT_SOURCES = err-sources.h err-codes.h code-to-errno.h code-from-errno.h \
+Index: libgpg-error-1.17/src/gpg-error.m4
+===================================================================
+--- libgpg-error-1.17.orig/src/gpg-error.m4
++++ libgpg-error-1.17/src/gpg-error.m4
+@@ -26,73 +26,13 @@ dnl is added to the gpg_config_script_wa
+ dnl
+ AC_DEFUN([AM_PATH_GPG_ERROR],
+ [ AC_REQUIRE([AC_CANONICAL_HOST])
+-  gpg_error_config_prefix=""
+-  dnl --with-libgpg-error-prefix=PFX is the preferred name for this option,
+-  dnl since that is consistent with how our three siblings use the directory/
+-  dnl package name in --with-$dir_name-prefix=PFX.
+-  AC_ARG_WITH(libgpg-error-prefix,
+-              AC_HELP_STRING([--with-libgpg-error-prefix=PFX],
+-                             [prefix where GPG Error is installed (optional)]),
+-              [gpg_error_config_prefix="$withval"])
+-
+-  dnl Accept --with-gpg-error-prefix and make it work the same as
+-  dnl --with-libgpg-error-prefix above, for backwards compatibility,
+-  dnl but do not document this old, inconsistently-named option.
+-  AC_ARG_WITH(gpg-error-prefix,,
+-              [gpg_error_config_prefix="$withval"])
++  min_gpg_error_version=ifelse([$1], ,0.0,$1)
+ 
+-  if test x"${GPG_ERROR_CONFIG}" = x ; then
+-     if test x"${gpg_error_config_prefix}" != x ; then
+-        GPG_ERROR_CONFIG="${gpg_error_config_prefix}/bin/gpg-error-config"
+-     else
+-       case "${SYSROOT}" in
+-         /*)
+-           if test -x "${SYSROOT}/bin/gpg-error-config" ; then
+-             GPG_ERROR_CONFIG="${SYSROOT}/bin/gpg-error-config"
+-           fi
+-           ;;
+-         '')
+-           ;;
+-          *)
+-           AC_MSG_WARN([Ignoring \$SYSROOT as it is not an absolute path.])
+-           ;;
+-       esac
+-     fi
+-  fi
++  PKG_CHECK_MODULES(GPG_ERROR, [gpg-error >= $min_gpg_error_version], [ok=yes], [ok=no])
+ 
+-  AC_PATH_PROG(GPG_ERROR_CONFIG, gpg-error-config, no)
+-  min_gpg_error_version=ifelse([$1], ,0.0,$1)
+-  AC_MSG_CHECKING(for GPG Error - version >= $min_gpg_error_version)
+-  ok=no
+-  if test "$GPG_ERROR_CONFIG" != "no" \
+-     && test -f "$GPG_ERROR_CONFIG" ; then
+-    req_major=`echo $min_gpg_error_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)/\1/'`
+-    req_minor=`echo $min_gpg_error_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
+-    gpg_error_config_version=`$GPG_ERROR_CONFIG $gpg_error_config_args --version`
+-    major=`echo $gpg_error_config_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
+-    minor=`echo $gpg_error_config_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\2/'`
+-    if test "$major" -gt "$req_major"; then
+-        ok=yes
+-    else
+-        if test "$major" -eq "$req_major"; then
+-            if test "$minor" -ge "$req_minor"; then
+-               ok=yes
+-            fi
+-        fi
+-    fi
+-  fi
+   if test $ok = yes; then
+-    GPG_ERROR_CFLAGS=`$GPG_ERROR_CONFIG $gpg_error_config_args --cflags`
+-    GPG_ERROR_LIBS=`$GPG_ERROR_CONFIG $gpg_error_config_args --libs`
+-    GPG_ERROR_MT_CFLAGS=`$GPG_ERROR_CONFIG $gpg_error_config_args --mt --cflags 2>/dev/null`
+-    GPG_ERROR_MT_LIBS=`$GPG_ERROR_CONFIG $gpg_error_config_args --mt --libs 2>/dev/null`
+-    AC_MSG_RESULT([yes ($gpg_error_config_version)])
+     ifelse([$2], , :, [$2])
+-    gpg_error_config_host=`$GPG_ERROR_CONFIG $gpg_error_config_args --host 2>/dev/null || echo none`
++    gpg_error_config_host=`$PKG_CONFIG --variable=host gpg-error`
+     if test x"$gpg_error_config_host" != xnone ; then
+       if test x"$gpg_error_config_host" != x"$host" ; then
+   AC_MSG_WARN([[
+@@ -107,11 +47,6 @@ AC_DEFUN([AM_PATH_GPG_ERROR],
+       fi
+     fi
+   else
+-    GPG_ERROR_CFLAGS=""
+-    GPG_ERROR_LIBS=""
+-    GPG_ERROR_MT_CFLAGS=""
+-    GPG_ERROR_MT_LIBS=""
+-    AC_MSG_RESULT(no)
+     ifelse([$3], , :, [$3])
+   fi
+   AC_SUBST(GPG_ERROR_CFLAGS)
+Index: libgpg-error-1.17/src/gpg-error.pc.in
+===================================================================
+--- /dev/null
++++ libgpg-error-1.17/src/gpg-error.pc.in
+@@ -0,0 +1,11 @@
++prefix=@prefix@
++exec_prefix=@exec_prefix@
++libdir=@libdir@
++includedir=@includedir@
++host=@GPG_ERROR_CONFIG_HOST@
++
++Name: gpg-error
++Description: a library that defines common error values for all GnuPG components
++Version: @VERSION@
++Libs: -L${libdir} -lgpg-error
++Cflags: -I${includedir}

--- a/recipes-debian/libgpg-error/libgpg-error_debian.bb
+++ b/recipes-debian/libgpg-error/libgpg-error_debian.bb
@@ -8,7 +8,9 @@ SUMMARY = "Small library that defines common error values for all GnuPG componen
 HOMEPAGE = "http://www.gnupg.org/related_software/libgpg-error/"
 BUGTRACKER = "https://bugs.g10code.com/gnupg/index"
 
-inherit debian-package autotools binconfig pkgconfig gettext
+BINCONFIG = "${bindir}/gpg-error-config"
+
+inherit debian-package autotools binconfig-disabled pkgconfig gettext
 PV = "1.17"
 
 PR = "r0"
@@ -19,6 +21,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552 \
                     file://src/gpg-error.h.in;endline=23;md5=5dfe776dc8b62af093ddc859de6f494c \
                     file://src/init.c;endline=20;md5=8f5a9b59634f4aebcd0ec9d3ebd53bfe \
 "
+
+# base on meta/recipes-support/libgpg-error/libgpg-error/pkgconfig.patch
+SRC_URI += "file://pkgconfig.patch"
 
 EXTRA_OECONF = "--enable-static --disable-rpath"
 

--- a/recipes-debian/libpcap/libpcap_debian.bb
+++ b/recipes-debian/libpcap/libpcap_debian.bb
@@ -22,7 +22,9 @@ PR = "r0"
 inherit debian-package
 PV = "1.6.2"
 
-inherit autotools-brokensep bluetooth
+BINCONFIG = "${bindir}/pcap-config"
+
+inherit autotools-brokensep bluetooth binconfig-disabled
 
 EXTRA_OECONF = "--with-pcap=linux"
 

--- a/recipes-debian/libpcre/libpcre_debian.bb
+++ b/recipes-debian/libpcre/libpcre_debian.bb
@@ -11,7 +11,9 @@ to the POSIX regular expression API."
 SUMMARY = "Perl Compatible Regular Expressions"
 HOMEPAGE = "http://www.pcre.org"
 
-inherit autotools binconfig ptest debian-package
+BINCONFIG = "${bindir}/pcre-config"
+
+inherit autotools binconfig-disabled ptest debian-package
 PV = "8.35"
 PR = "r0"
 DPN = "pcre3"

--- a/recipes-debian/libpng/libpng_debian.bb
+++ b/recipes-debian/libpng/libpng_debian.bb
@@ -9,7 +9,10 @@ HOMEPAGE = "http://www.libpng.org/"
 
 inherit debian-package
 PV = "1.2.50"
-inherit autotools binconfig pkgconfig
+
+BINCONFIG = "${bindir}/libpng-config ${bindir}/libpng12-config"
+
+inherit autotools binconfig-disabled pkgconfig
 
 PR = "r1"
 DEPENDS = "zlib"

--- a/recipes-debian/libprelude/files/configure-use-pkg-config-for-libgcrypt-detection.patch
+++ b/recipes-debian/libprelude/files/configure-use-pkg-config-for-libgcrypt-detection.patch
@@ -1,0 +1,67 @@
+configure: use pkg-config for libgcrypt detection
+
+diff --git a/m4/libgcrypt.m4 b/m4/libgcrypt.m4
+index 20bd105..e9e9e47 100644
+--- a/m4/libgcrypt.m4
++++ b/m4/libgcrypt.m4
+@@ -41,38 +41,8 @@ AC_DEFUN([AM_PATH_LIBGCRYPT],
+      min_libgcrypt_version="$tmp"
+   fi
+ 
+-  AC_MSG_CHECKING(for LIBGCRYPT - version >= $min_libgcrypt_version)
+-  ok=no
+-  if test "$LIBGCRYPT_CONFIG" != "no" ; then
+-    req_major=`echo $min_libgcrypt_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\1/'`
+-    req_minor=`echo $min_libgcrypt_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\2/'`
+-    req_micro=`echo $min_libgcrypt_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\)/\3/'`
+-    libgcrypt_config_version=`$LIBGCRYPT_CONFIG --version`
+-    major=`echo $libgcrypt_config_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
+-    minor=`echo $libgcrypt_config_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\2/'`
+-    micro=`echo $libgcrypt_config_version | \
+-               sed 's/\([[0-9]]*\)\.\([[0-9]]*\)\.\([[0-9]]*\).*/\3/'`
+-    if test "$major" -gt "$req_major"; then
+-        ok=yes
+-    else 
+-        if test "$major" -eq "$req_major"; then
+-            if test "$minor" -gt "$req_minor"; then
+-               ok=yes
+-            else
+-               if test "$minor" -eq "$req_minor"; then
+-                   if test "$micro" -ge "$req_micro"; then
+-                     ok=yes
+-                   fi
+-               fi
+-            fi
+-        fi
+-    fi
+-  fi
++  PKG_CHECK_MODULES(LIBGCRYPT, [libgcrypt >= $min_libgcrypt_version], [ok=yes], [ok=no])
++
+   if test $ok = yes; then
+     AC_MSG_RESULT(yes)
+   else
+@@ -82,7 +52,7 @@ AC_DEFUN([AM_PATH_LIBGCRYPT],
+      # If we have a recent libgcrypt, we should also check that the
+      # API is compatible
+      if test "$req_libgcrypt_api" -gt 0 ; then
+-        tmp=`$LIBGCRYPT_CONFIG --api-version 2>/dev/null || echo 0`
++        tmp=`$PKG_CONFIG --variable=api_version libgcrypt`
+         if test "$tmp" -gt 0 ; then
+            AC_MSG_CHECKING([LIBGCRYPT API version])
+            if test "$req_libgcrypt_api" -eq "$tmp" ; then
+@@ -95,8 +65,8 @@ AC_DEFUN([AM_PATH_LIBGCRYPT],
+      fi
+   fi
+   if test $ok = yes; then
+-    LIBGCRYPT_CFLAGS=`$LIBGCRYPT_CONFIG --cflags`
+-    LIBGCRYPT_LIBS=`$LIBGCRYPT_CONFIG --libs`
++    LIBGCRYPT_CFLAGS=`$PKG_CONFIG --cflags libgcrypt`
++    LIBGCRYPT_LIBS=`$PKG_CONFIG --libs libgcrypt`
+     ifelse([$2], , :, [$2])
+   else
+     LIBGCRYPT_CFLAGS=""

--- a/recipes-debian/libprelude/libprelude_debian.bb
+++ b/recipes-debian/libprelude/libprelude_debian.bb
@@ -42,6 +42,7 @@ SRC_URI += " \
     file://libprelude-perl-build-with-gnu-hash.patch \
     file://libprelude-fix-uid-gid-conflicting-types.patch \
     file://python-setup_py-install-prefix.patch \
+    file://configure-use-pkg-config-for-libgcrypt-detection.patch \
 "
 
 inherit autotools-brokensep gettext cpan-base binconfig pkgconfig perlnative pythonnative distutils-base

--- a/recipes-debian/libproxy/libproxy_debian.bb
+++ b/recipes-debian/libproxy/libproxy_debian.bb
@@ -28,6 +28,7 @@ SHLIBVER = "0.4.11"
 EXTRA_OECMAKE = " \
     -DWITH_VALA=ON -DWITH_GNOME3=ON \
     -DCMAKE_SKIP_RPATH=ON \
+    -DWITH_PERL=no \
     -DBIPR=0 \
     -DLIB_INSTALL_DIR=${libdir} \
     -DLIBEXEC_INSTALL_DIR=${libdir}/${DPN}/${SHLIBVER} \

--- a/recipes-debian/libsdl/files/pkgconfig.patch
+++ b/recipes-debian/libsdl/files/pkgconfig.patch
@@ -1,0 +1,187 @@
+Rather than code which doesn't even work properly when cross compiling,
+lets just use pkg-config instead. Its a little simpler.
+
+RP 2014/6/20
+
+Upstream-Status: Pending
+
+Index: SDL-1.2.15/sdl.m4
+===================================================================
+--- SDL-1.2.15.orig/sdl.m4
++++ SDL-1.2.15/sdl.m4
+@@ -12,174 +12,8 @@ dnl Test for SDL, and define SDL_CFLAGS
+ dnl
+ AC_DEFUN([AM_PATH_SDL],
+ [dnl 
+-dnl Get the cflags and libraries from the sdl-config script
+-dnl
+-AC_ARG_WITH(sdl-prefix,[  --with-sdl-prefix=PFX   Prefix where SDL is installed (optional)],
+-            sdl_prefix="$withval", sdl_prefix="")
+-AC_ARG_WITH(sdl-exec-prefix,[  --with-sdl-exec-prefix=PFX Exec prefix where SDL is installed (optional)],
+-            sdl_exec_prefix="$withval", sdl_exec_prefix="")
+-AC_ARG_ENABLE(sdltest, [  --disable-sdltest       Do not try to compile and run a test SDL program],
+-		    , enable_sdltest=yes)
+-
+-  if test x$sdl_exec_prefix != x ; then
+-    sdl_config_args="$sdl_config_args --exec-prefix=$sdl_exec_prefix"
+-    if test x${SDL_CONFIG+set} != xset ; then
+-      SDL_CONFIG=$sdl_exec_prefix/bin/sdl-config
+-    fi
+-  fi
+-  if test x$sdl_prefix != x ; then
+-    sdl_config_args="$sdl_config_args --prefix=$sdl_prefix"
+-    if test x${SDL_CONFIG+set} != xset ; then
+-      SDL_CONFIG=$sdl_prefix/bin/sdl-config
+-    fi
+-  fi
+-
+-  as_save_PATH="$PATH"
+-  if test "x$prefix" != xNONE; then
+-    PATH="$prefix/bin:$prefix/usr/bin:$PATH"
+-  fi
+-  AC_PATH_PROG(SDL_CONFIG, sdl-config, no, [$PATH])
+-  PATH="$as_save_PATH"
+   min_sdl_version=ifelse([$1], ,0.11.0,$1)
+-  AC_MSG_CHECKING(for SDL - version >= $min_sdl_version)
+-  no_sdl=""
+-  if test "$SDL_CONFIG" = "no" ; then
+-    no_sdl=yes
+-  else
+-    SDL_CFLAGS=`$SDL_CONFIG $sdl_config_args --cflags`
+-    SDL_LIBS=`$SDL_CONFIG $sdl_config_args --libs`
+-
+-    sdl_major_version=`$SDL_CONFIG $sdl_config_args --version | \
+-           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
+-    sdl_minor_version=`$SDL_CONFIG $sdl_config_args --version | \
+-           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\2/'`
+-    sdl_micro_version=`$SDL_CONFIG $sdl_config_args --version | \
+-           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\3/'`
+-    if test "x$enable_sdltest" = "xyes" ; then
+-      ac_save_CFLAGS="$CFLAGS"
+-      ac_save_CXXFLAGS="$CXXFLAGS"
+-      ac_save_LIBS="$LIBS"
+-      CFLAGS="$CFLAGS $SDL_CFLAGS"
+-      CXXFLAGS="$CXXFLAGS $SDL_CFLAGS"
+-      LIBS="$LIBS $SDL_LIBS"
+-dnl
+-dnl Now check if the installed SDL is sufficiently new. (Also sanity
+-dnl checks the results of sdl-config to some extent
+-dnl
+-      rm -f conf.sdltest
+-      AC_TRY_RUN([
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <string.h>
+-#include "SDL.h"
+-
+-char*
+-my_strdup (char *str)
+-{
+-  char *new_str;
+-  
+-  if (str)
+-    {
+-      new_str = (char *)malloc ((strlen (str) + 1) * sizeof(char));
+-      strcpy (new_str, str);
+-    }
+-  else
+-    new_str = NULL;
+-  
+-  return new_str;
+-}
+-
+-int main (int argc, char *argv[])
+-{
+-  int major, minor, micro;
+-  char *tmp_version;
+-
+-  /* This hangs on some systems (?)
+-  system ("touch conf.sdltest");
+-  */
+-  { FILE *fp = fopen("conf.sdltest", "a"); if ( fp ) fclose(fp); }
+-
+-  /* HP/UX 9 (%@#!) writes to sscanf strings */
+-  tmp_version = my_strdup("$min_sdl_version");
+-  if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
+-     printf("%s, bad version string\n", "$min_sdl_version");
+-     exit(1);
+-   }
+-
+-   if (($sdl_major_version > major) ||
+-      (($sdl_major_version == major) && ($sdl_minor_version > minor)) ||
+-      (($sdl_major_version == major) && ($sdl_minor_version == minor) && ($sdl_micro_version >= micro)))
+-    {
+-      return 0;
+-    }
+-  else
+-    {
+-      printf("\n*** 'sdl-config --version' returned %d.%d.%d, but the minimum version\n", $sdl_major_version, $sdl_minor_version, $sdl_micro_version);
+-      printf("*** of SDL required is %d.%d.%d. If sdl-config is correct, then it is\n", major, minor, micro);
+-      printf("*** best to upgrade to the required version.\n");
+-      printf("*** If sdl-config was wrong, set the environment variable SDL_CONFIG\n");
+-      printf("*** to point to the correct copy of sdl-config, and remove the file\n");
+-      printf("*** config.cache before re-running configure\n");
+-      return 1;
+-    }
+-}
+-
+-],, no_sdl=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
+-       CFLAGS="$ac_save_CFLAGS"
+-       CXXFLAGS="$ac_save_CXXFLAGS"
+-       LIBS="$ac_save_LIBS"
+-     fi
+-  fi
+-  if test "x$no_sdl" = x ; then
+-     AC_MSG_RESULT(yes)
+-     ifelse([$2], , :, [$2])     
+-  else
+-     AC_MSG_RESULT(no)
+-     if test "$SDL_CONFIG" = "no" ; then
+-       echo "*** The sdl-config script installed by SDL could not be found"
+-       echo "*** If SDL was installed in PREFIX, make sure PREFIX/bin is in"
+-       echo "*** your path, or set the SDL_CONFIG environment variable to the"
+-       echo "*** full path to sdl-config."
+-     else
+-       if test -f conf.sdltest ; then
+-        :
+-       else
+-          echo "*** Could not run SDL test program, checking why..."
+-          CFLAGS="$CFLAGS $SDL_CFLAGS"
+-          CXXFLAGS="$CXXFLAGS $SDL_CFLAGS"
+-          LIBS="$LIBS $SDL_LIBS"
+-          AC_TRY_LINK([
+-#include <stdio.h>
+-#include "SDL.h"
+-
+-int main(int argc, char *argv[])
+-{ return 0; }
+-#undef  main
+-#define main K_and_R_C_main
+-],      [ return 0; ],
+-        [ echo "*** The test program compiled, but did not run. This usually means"
+-          echo "*** that the run-time linker is not finding SDL or finding the wrong"
+-          echo "*** version of SDL. If it is not finding SDL, you'll need to set your"
+-          echo "*** LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf to point"
+-          echo "*** to the installed location  Also, make sure you have run ldconfig if that"
+-          echo "*** is required on your system"
+-	  echo "***"
+-          echo "*** If you have an old version installed, it is best to remove it, although"
+-          echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH"],
+-        [ echo "*** The test program failed to compile or link. See the file config.log for the"
+-          echo "*** exact error that occured. This usually means SDL was incorrectly installed"
+-          echo "*** or that you have moved SDL since it was installed. In the latter case, you"
+-          echo "*** may want to edit the sdl-config script: $SDL_CONFIG" ])
+-          CFLAGS="$ac_save_CFLAGS"
+-          CXXFLAGS="$ac_save_CXXFLAGS"
+-          LIBS="$ac_save_LIBS"
+-       fi
+-     fi
+-     SDL_CFLAGS=""
+-     SDL_LIBS=""
+-     ifelse([$3], , :, [$3])
+-  fi
++  PKG_CHECK_MODULES([SDL], [sdl >= $min_sdl_version], [sdl_enabled=yes], [sdl_enabled=no])
+   AC_SUBST(SDL_CFLAGS)
+   AC_SUBST(SDL_LIBS)
+-  rm -f conf.sdltest
+ ])

--- a/recipes-debian/libsdl/libsdl_debian.bb
+++ b/recipes-debian/libsdl/libsdl_debian.bb
@@ -18,6 +18,9 @@ PV = "1.2.15"
 #Correct the debian package name
 DPN ="libsdl1.2"
 
+# base on meta/recipes-graphics/libsdl/libsdl-1.2.15/pkgconfig.patch
+SRC_URI += "file://pkgconfig.patch"
+
 LICENSE = "LGPLv2.1"
 LIC_FILES_CHKSUM = "file://COPYING;md5=27818cd7fd83877a8e3ef82b82798ef4"
 
@@ -32,6 +35,8 @@ DEPENDS_class-nativesdk = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', \
 			   nativesdk-libxrender nativesdk-libxext', '', d)}"
 
 PROVIDES = "virtual/libsdl"
+
+BINCONFIG = "${bindir}/sdl-config"
 
 inherit autotools lib_package binconfig-disabled
 

--- a/recipes-debian/libxslt/libxslt_debian.bb
+++ b/recipes-debian/libxslt/libxslt_debian.bb
@@ -21,7 +21,9 @@ SRC_URI += "file://0001-Use-pkg-config-to-find-gcrypt-and-libxml2.patch"
 
 EXTRA_OECONF = "--without-python --without-debug --without-mem-debug --without-crypto"
 
-inherit autotools pkgconfig binconfig lib_package
+BINCONFIG = "${bindir}/xslt-config"
+
+inherit autotools pkgconfig binconfig-disabled lib_package
 
 # We don't DEPEND on binutils for ansidecl.h so ensure we don't use the header
 do_configure_prepend () {

--- a/recipes-debian/ncurses/ncurses_debian.bb
+++ b/recipes-debian/ncurses/ncurses_debian.bb
@@ -8,7 +8,9 @@ SUMMARY = "The New Curses library"
 DESCRIPTION = "SVr4 and XSI-Curses compatible curses library and terminfo tools including tic, infocmp, captoinfo. Supports color, multiple highlights, forms-drawing characters, and automatic recognition of keypad and function-key sequences. Extensions include resizable windows and mouse support on both xterm and Linux console using the gpm library."
 HOMEPAGE = "http://www.gnu.org/software/ncurses/ncurses.html"
 
-inherit debian-package autotools binconfig multilib_header update-alternatives
+BINCONFIG = "${bindir}/ncurses5-config ${bindir}/ncursesw5-config"
+
+inherit debian-package autotools binconfig-disabled multilib_header update-alternatives
 PV = "5.9+20140913"
 
 PR = "r1"

--- a/recipes-debian/newt/files/Makefile.in-Add-tinfo-library-to-the-linking-librari.patch
+++ b/recipes-debian/newt/files/Makefile.in-Add-tinfo-library-to-the-linking-librari.patch
@@ -1,0 +1,26 @@
+From fad40cfc18a42946a9a9e440c3434cd6b847ff9d Mon Sep 17 00:00:00 2001
+From: Otavio Salvador <otavio@ossystems.com.br>
+Date: Mon, 18 Jan 2016 17:05:19 +0000
+Subject: [PATCH] Makefile.in: Add tinfo library to the linking libraries
+Organization: O.S. Systems Software LTDA.
+
+Upstream-Status: Pending
+
+Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+---
+ Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index a85d00f..98b85f9 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1,4 +1,4 @@
+-LIBS = -lslang @LIBS@
++LIBS = -lslang -ltinfo @LIBS@
+ LIBTCL = @TCL_LIB_FLAG@
+ 
+ CC = @CC@
+-- 
+2.1.4
+

--- a/recipes-debian/newt/libnewt_debian.bb
+++ b/recipes-debian/newt/libnewt_debian.bb
@@ -37,6 +37,7 @@ SRC_URI += " \
 	file://fix_SHAREDDIR.patch \
 	file://cross_ar.patch \
 	file://disable_python_dbg.patch \
+	file://Makefile.in-Add-tinfo-library-to-the-linking-librari.patch \
 "
 
 DPN = "newt"

--- a/recipes-debian/swig/files/0001-configure-use-pkg-config-for-pcre-detection.patch
+++ b/recipes-debian/swig/files/0001-configure-use-pkg-config-for-pcre-detection.patch
@@ -1,0 +1,64 @@
+From 5c4d6d8538994d5fe9b3b46bfafaf0a605e3bda6 Mon Sep 17 00:00:00 2001
+From: Koen Kooi <koen.kooi@linaro.org>
+Date: Tue, 17 Jun 2014 08:18:17 +0200
+Subject: [PATCH] configure: use pkg-config for pcre detection
+
+Signed-off-by: Koen Kooi <koen.kooi@linaro.org>
+Upstream-Status: pending
+---
+ configure.ac | 38 +++++++-------------------------------
+ 1 file changed, 7 insertions(+), 31 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 0c984b7..6edcec1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -70,38 +70,14 @@ AC_MSG_RESULT([$with_pcre])
+ 
+ dnl To make configuring easier, check for a locally built PCRE using the Tools/pcre-build.sh script
+ if test x"${with_pcre}" = xyes ; then
+-  AC_MSG_CHECKING([whether to use local PCRE])
+-  local_pcre_config=no
+-  if test -z $PCRE_CONFIG; then
+-    if test -f `pwd`/pcre/pcre-swig-install/bin/pcre-config; then
+-      PCRE_CONFIG=`pwd`/pcre/pcre-swig-install/bin/pcre-config
+-      local_pcre_config=$PCRE_CONFIG
+-    fi
+-  fi
+-  AC_MSG_RESULT([$local_pcre_config])
+-fi
+-AS_IF([test "x$with_pcre" != xno],
+-  [AX_PATH_GENERIC([pcre],
+-    [], dnl Minimal version of PCRE we need -- accept any
+-    [], dnl custom sed script for version parsing is not needed
+-    [AC_DEFINE([HAVE_PCRE], [1], [Define if you have PCRE library])
+-     LIBS="$LIBS $PCRE_LIBS"
+-     CPPFLAGS="$CPPFLAGS $PCRE_CFLAGS"
+-    ],
+-    [AC_MSG_FAILURE([
+-        Cannot find pcre-config script from PCRE (Perl Compatible Regular Expressions)
+-        library package. This dependency is needed for configure to complete,
+-        Either:
+-        - Install the PCRE developer package on your system (preferred approach).
+-        - Download the PCRE source tarball, build and install on your system
+-          as you would for any package built from source distribution.
+-        - Use the Tools/pcre-build.sh script to build PCRE just for SWIG to statically
+-          link against. Run 'Tools/pcre-build.sh --help' for instructions.
+-          (quite easy and does not require privileges to install PCRE on your system)
+-        - Use configure --without-pcre to disable regular expressions support in SWIG
+-          (not recommended).])
+-    ])
++  PKG_CHECK_MODULES([PCRE], [libpcre], [
++    AC_DEFINE([HAVE_PCRE], [1], [Define if you have PCRE library])
++    LIBS="$LIBS $PCRE_LIBS"
++    CPPFLAGS="$CPPFLAGS $PCRE_CFLAGS"
++  ], [
++    AC_MSG_WARN([$PCRE_PKG_ERRORS])
+   ])
++fi
+ 
+ 
+ dnl CCache
+-- 
+1.9.3
+

--- a/recipes-debian/swig/swig_debian.bb
+++ b/recipes-debian/swig/swig_debian.bb
@@ -10,6 +10,9 @@ LIC_FILES_CHKSUM = " \
 file://LICENSE;md5=e7807a6282784a7dde4c846626b08fc6 \
 "
 
+# base on meta/recipes-devtools/swig/swig/0001-configure-use-pkg-config-for-pcre-detection.patch
+SRC_URI += "file://0001-configure-use-pkg-config-for-pcre-detection.patch"
+
 DEPENDS = "python libpcre tcl"
 
 # Path to find tclConfig.sh

--- a/recipes-debian/uwsgi/files/0001-Use-pkg-config-for-libxml2-libpcre-detection.patch
+++ b/recipes-debian/uwsgi/files/0001-Use-pkg-config-for-libxml2-libpcre-detection.patch
@@ -1,7 +1,37 @@
+Use pkg-config for libxml2 and libpcre detection
+
 diff --git a/uwsgiconfig.py b/uwsgiconfig.py
-index b594462..8652bd6 100644
+index b594462..9fa66ae 100644
 --- a/uwsgiconfig.py
 +++ b/uwsgiconfig.py
+@@ -1004,23 +1004,23 @@ class uConf(object):
+         # re-enable after pcre fix
+         if self.get('pcre'):
+             if self.get('pcre') == 'auto':
+-                pcreconf = spcall('pcre-config --libs')
++                pcreconf = spcall('pkg-config --libs libpcre')
+                 if pcreconf:
+                     self.libs.append(pcreconf)
+-                    pcreconf = spcall("pcre-config --cflags")
++                    pcreconf = spcall("pkg-config --cflags libpcre")
+                     self.cflags.append(pcreconf)
+                     self.gcc_list.append('core/regexp')
+                     self.cflags.append("-DUWSGI_PCRE")
+                     has_pcre = True
+ 
+             else:
+-                pcreconf = spcall('pcre-config --libs')
++                pcreconf = spcall('pkg-config --libs libpcre')
+                 if pcreconf is None:
+                     print("*** libpcre headers unavailable. uWSGI build is interrupted. You have to install pcre development package or disable pcre")
+                     sys.exit(1)
+                 else:
+                     self.libs.append(pcreconf)
+-                    pcreconf = spcall("pcre-config --cflags")
++                    pcreconf = spcall("pkg-config --cflags libpcre")
+                     self.cflags.append(pcreconf)
+                     self.gcc_list.append('core/regexp')
+                     self.cflags.append("-DUWSGI_PCRE")
 @@ -1233,10 +1233,10 @@ class uConf(object):
  
          if self.get('xml'):

--- a/recipes-debian/uwsgi/uwsgi_debian.bb
+++ b/recipes-debian/uwsgi/uwsgi_debian.bb
@@ -21,7 +21,7 @@ PV = "2.0.7"
 LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=33ab1ce13e2312dddfad07f97f66321f"
 
-SRC_URI += "file://0001-Use-pkg-config-for-libxml2-detection.patch"
+SRC_URI += "file://0001-Use-pkg-config-for-libxml2-libpcre-detection.patch"
 
 inherit setuptools pkgconfig update-alternatives
 


### PR DESCRIPTION
The -config file is installed but we wish to disable it and just rely on the .pc files instead (by using pkg-config).

The packages changed are base on meta layer, and the dependency packages also need to be fixed.