### PR TITLE
pseudo: Backport bug fix patch from upstream

### DIFF
--- a/recipes-debian/pseudo/pseudo/0001-don-t-renameat2-please.patch
+++ b/recipes-debian/pseudo/pseudo/0001-don-t-renameat2-please.patch
@@ -1,0 +1,74 @@
+From c1375a6df4379c620d4e2a622eb58e5d7a1b556a Mon Sep 17 00:00:00 2001
+From: Seebs <seebs@seebs.net>
+Date: Tue, 9 Apr 2019 18:05:43 -0500
+Subject: [PATCH] don't renameat2 please
+
+commit 6ebc7d6bc8ab973d0ba949eeb363821811ce8dc5 upstream
+
+So renameat2 now has a glibc wrapper in some recent glibc, which
+means that mv can use it, and thus bypass all our clever testing,
+and since we can't intercept the actual syscall (gnulib's implementation
+apparently doesn't hit the glibc syscall() wrapper?), this results
+in files being moved without pseudo knowing about them.
+
+Implementing the semantics properly is Very Hard, but possibly we
+can just fail politely for now.
+
+We'll be back to this later.
+---
+ ChangeLog.txt                |  4 ++++
+ ports/linux/guts/renameat2.c | 20 ++++++++++++++++++++
+ ports/linux/wrapfuncs.in     |  1 +
+ 3 files changed, 25 insertions(+)
+ create mode 100644 ports/linux/guts/renameat2.c
+
+diff --git a/ChangeLog.txt b/ChangeLog.txt
+index e0c66fc..8b98dca 100644
+--- a/ChangeLog.txt
++++ b/ChangeLog.txt
+@@ -1,3 +1,7 @@
++2019-04-09:
++	* (seebs) Make a glibc renameat2 wrapper that just fails because
++	implementing renameat2 semantics is Surprisingly Hard.
++
+ 2018-09-20:
+ 	* (seebs) coerce inodes to signed int64_t range when shoving
+ 	  them into sqlite.
+diff --git a/ports/linux/guts/renameat2.c b/ports/linux/guts/renameat2.c
+new file mode 100644
+index 0000000..0df8369
+--- /dev/null
++++ b/ports/linux/guts/renameat2.c
+@@ -0,0 +1,20 @@
++/*
++ * Copyright (c) 2019 Peter Seebach/Seebs <seebs@seebs.net>; see
++ * guts/COPYRIGHT for information.
++ *
++ * [Note: copyright added by code generator, may be
++ * incorrect. Remove this if you fix it.]
++ *
++ * int renameat2(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, unsigned int flags)
++ *	int rc = -1;
++ */
++
++	/* for now, let's try just failing out hard, and hope things retry with a
++	 * different syscall.
++	 */
++	errno = ENOSYS;
++	rc = -1;
++
++/*	return rc;
++ * }
++ */
+diff --git a/ports/linux/wrapfuncs.in b/ports/linux/wrapfuncs.in
+index e47acc3..a129eba 100644
+--- a/ports/linux/wrapfuncs.in
++++ b/ports/linux/wrapfuncs.in
+@@ -55,3 +55,4 @@ int getpwent_r(struct passwd *pwbuf, char *buf, size_t buflen, struct passwd **p
+ int getgrent_r(struct group *gbuf, char *buf, size_t buflen, struct group **gbufp);
+ int capset(cap_user_header_t hdrp, const cap_user_data_t datap); /* real_func=pseudo_capset */
+ long syscall(long nr, ...); /* hand_wrapped=1 */
++int renameat2(int olddirfd, const char *oldpath, int newdirfd, const char *newpath, unsigned int flags); /* flags=AT_SYMLINK_NOFOLLOW */
+-- 
+2.20.1
+

--- a/recipes-debian/pseudo/pseudo_debian.bb
+++ b/recipes-debian/pseudo/pseudo_debian.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=243b725d71bb5df4a1e5920b344b86ad"
 
 inherit debian-package
 require recipes-debian/sources/pseudo.inc
-FILESPATH_append = ":${COREBASE}/meta/recipes-devtools/pseudo/files"
+FILESPATH_append = ":${COREBASE}/meta/recipes-devtools/pseudo/files:${THISDIR}/pseudo"
 
 SRC_URI += " \
            file://0001-configure-Prune-PIE-flags.patch \
@@ -18,4 +18,5 @@ SRC_URI += " \
            file://moreretries.patch \
            file://toomanyfiles.patch \
            file://0001-Add-statx.patch \
+           file://0001-don-t-renameat2-please.patch \
            "


### PR DESCRIPTION
Some packages, e.g. coreutils/gawk, use install-sh script(which is related to automak command) install softwares during install process. It uses mv command to move files. In poky build system, install process is working in fakeroot environment. This fakeroot environment is created by pseudo package.  However, package which use install-sh script got host-user-contaminated warning from poky in do_package_qa process. It seems main cause is using mv command during install process which may break fakeroot environment.

I checked poky but it doesn't have same problem. Then I found the differnece between meta-debian and poky is pseudo package version. The poky uses newer revision of pseudo package than debian. 
Finally I found a patch to fix renameat2 problem in upstream[1].  I backported"don't renameat2 please" patch and confirmed it dismise host-user-contaminated warning.

1:
https://git.yoctoproject.org/cgit/cgit.cgi/pseudo/commit/?id=6ebc7d6bc8ab973d0ba949eeb363821811ce8dc5

I got following warnings when build coreutils package.

```
masami@debian10:~/metadebian/build$ bitbake -f coreutils -c cleanall ; bitbake -f coreutils
coreutils: /coreutils/usr/bin/tty.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/uptime.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/realpath.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/chcon.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/tail.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/cut.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/sha384sum.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/shuf.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/sha1sum.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/md5sum.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/b2sum is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/df.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/pr.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/head.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/cksum.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/tac.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/ptx.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/sha512sum.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/whoami.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/mktemp.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/hostid.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/groups.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/unlink.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/expr.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/sum.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/nproc.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/usr/bin/dirname.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/chown.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/false.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/cp.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/dd.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/cat.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/sleep.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/rmdir.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/stat.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/hostname.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/chgrp.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/pwd.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/rm.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/ls.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/sync.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/true.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/mknod.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/stty.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/ln.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/date.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/mkdir.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/kill.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/mv.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/echo.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/touch.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/uname.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
coreutils: /coreutils/bin/chmod.coreutils is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination [host-user-contaminated]
NOTE: Tasks Summary: Attempted 1922 tasks of which 1906 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```

I got following warning when build gawk package.

```
WARNING: gawk-4.2.1-r0 do_package_qa: QA Issue: gawk: /gawk/etc/profile.d/gawk.csh is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination
gawk: /gawk/usr/libexec/awk/grcat is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination [host-user-contaminated]
NOTE: Tasks Summary: Attempted 1922 tasks of which 1903 didn't need to be rerun and all succeeded.
```
