### PR TITLE
recipes: Correct package name to build multilib

### DIFF
--- a/recipes-debian/bluez/bluez_debian.bb
+++ b/recipes-debian/bluez/bluez_debian.bb
@@ -90,14 +90,14 @@ do_install_append() {
 ALLOW_EMPTY_libasound-module-bluez = "1"
 PACKAGES =+ " \
 	libasound-module-bluez \
-	${PN}-obex \
-	${PN}-cups \
-	${PN}-hcidump \
+	${DPN}-obex \
+	${DPN}-cups \
+	${DPN}-hcidump \
 	libbluetooth \
 "
 
-FILES_${PN}-cups = "${nonarch_libdir}/cups/backend/bluetooth"
-FILES_${PN}-hcidump = "${bindir}/hcidump"
+FILES_${DPN}-cups = "${nonarch_libdir}/cups/backend/bluetooth"
+FILES_${DPN}-hcidump = "${bindir}/hcidump"
 FILES_libbluetooth = "${libdir}/libbluetooth.so.* ${libdir}/bluetooth/plugins/*.so"
 
 FILES_libasound-module-bluez = "${libdir}/alsa-lib/lib*.so ${datadir}/alsa"
@@ -117,12 +117,12 @@ FILES_${PN}-dev += "\
 
 FILES_${PN}-staticdev += "${libdir}/bluetooth/plugins/*.a"
 
-FILES_${PN}-obex = " \
+FILES_${DPN}-obex = " \
 	${nonarch_libdir}/bluetooth/obexd \
 	${nonarch_libdir}/systemd/user/obex.service \
 	${datadir}/dbus-1/services/org.bluez.obex.service \
 "
-SYSTEMD_SERVICE_${PN}-obex = "obex.service"
+SYSTEMD_SERVICE_${DPN}-obex = "obex.service"
 
 FILES_${PN}-dbg += "\
 	${libdir}/bluetooth/.debug \
@@ -137,5 +137,5 @@ SYSTEMD_SERVICE_${PN} = "bluetooth.service"
 EXCLUDE_FROM_WORLD = "1"
 
 DEBIANNAME_libbluetooth = "libbluetooth3"
-DEBIANNAME_${PN}-obex = "${PN}-obexd"
-DEBIANNAME_${PN}-dev = "libbluetooth-dev"
+DEBIANNAME_${DPN}-obex = "${DPN}-obexd"
+DEBIANNAME_${DPN}-dev = "libbluetooth-dev"

--- a/recipes-debian/dbus/dbus_debian.bb
+++ b/recipes-debian/dbus/dbus_debian.bb
@@ -46,8 +46,8 @@ USERADD_PARAM_${PN} = "--system --home ${localstatedir}/lib/dbus \
 
 CONFFILES_${PN} = "${sysconfdir}/dbus-1/system.conf ${sysconfdir}/dbus-1/session.conf"
 
-DEBIANNAME_${PN}-dbg = "${PN}-1-dbg"
-DEBIANNAME_${PN}-doc = "${PN}-1-doc"
+DEBIANNAME_${PN}-dbg = "${DPN}-1-dbg"
+DEBIANNAME_${PN}-doc = "${DPN}-1-doc"
 
 PACKAGES =+ "${PN}-lib"
 

--- a/recipes-debian/gconf/gconf_debian.bb
+++ b/recipes-debian/gconf/gconf_debian.bb
@@ -98,7 +98,7 @@ pkg_postinst_${PN}() {
 	fi
 }
 
-PACKAGES =+ "${PN}-gsettings-backend ${PN}-service ${PN}-common lib${DPN}"
+PACKAGES =+ "${PN}-gsettings-backend ${PN}-service ${DPN}-common lib${DPN}"
 
 FILES_${PN}-gsettings-backend = "${libdir}/gio/modules/libgsettingsgconfbackend.so"
 FILES_${PN}-service = "${libdir}/gconf/*/* \
@@ -113,10 +113,10 @@ FILES_${PN}-dbg += "${libdir}/gconf/*/.debug"
 
 DEBIANNAME_${PN}-dev = "libgconf2-dev"
 RPROVIDES_${PN}-dev = "libgconf2-dev"
-DEBIANNAME_${PN} = "${PN}2"
-RPROVIDES_${PN} = "${PN}2"
-DEBIANNAME_${PN}-common = "${PN}2-common"
-RPROVIDES_${PN}-common = "${PN}2-common"
+DEBIANNAME_${PN} = "${DPN}2"
+RPROVIDES_${PN} = "${DPN}2"
+DEBIANNAME_${PN}-common = "${DPN}2-common"
+RPROVIDES_${PN}-common = "${DPN}2-common"
 RPROVIDES_lib${DPN} = "lib${DPN}-2-4 lib${DPN}2-4"
 
 # Base on debian/control

--- a/recipes-debian/geoip/geoip_debian.bb
+++ b/recipes-debian/geoip/geoip_debian.bb
@@ -46,9 +46,9 @@ do_install_append() {
 	rm ${D}${libdir}/libGeoIP.la		
 }
 #Correct the package name
-DEBIANNAME_${PN} = "${PN}-bin"
+DEBIANNAME_${PN} = "${DPN}-bin"
 DEBIANNAME_${PN}-dev = "lib${DPN}-dev"
-RPROVIDES_${PN} += "${PN}-bin"
+RPROVIDES_${PN} += "${DPN}-bin"
 RPROVIDES_${PN}-dev += "lib${DPN}-dev"
 
 FILES_libgeoip = "${libdir}/libGeoIP.so.*"

--- a/recipes-debian/giflib/giflib_debian.bb
+++ b/recipes-debian/giflib/giflib_debian.bb
@@ -28,8 +28,8 @@ FILES_libgif = "${libdir}/libgif${SOLIBS}"
 RPROVIDES_libgif = "libgif4"
 
 RDEPENDS_${PN} = "perl"
-DEBIANNAME_${PN} = "${PN}-tools"
-RPROVIDES_${PN} = "${PN}-tools libungif-bin"
+DEBIANNAME_${PN} = "${DPN}-tools"
+RPROVIDES_${PN} = "${DPN}-tools libungif-bin"
 
 DEBIANNAME_${PN}-dev = "libgif-dev"
 RPROVIDES_${PN}-dev = "libgif-dev"

--- a/recipes-debian/libcap-ng/libcap-ng_debian.bb
+++ b/recipes-debian/libcap-ng/libcap-ng_debian.bb
@@ -52,7 +52,7 @@ FILES_${PN}-dbg += "${PYTHON_SITEPACKAGES_DIR}/.debug"
 RPROVIDES_python-cap-ng = "${PN}-python"
 
 # lib_package class provides libcap-ng-bin which is equal to libcap-ng-utils from Debian
-RPROVIDES_${PN}-bin = "${PN}-utils"
-DEBIANNAME_${PN}-bin = "${PN}-utils"
+RPROVIDES_${PN}-bin = "${DPN}-utils"
+DEBIANNAME_${PN}-bin = "${DPN}-utils"
 
 BBCLASSEXTEND = "native"

--- a/recipes-debian/libcap/libcap_debian.bb
+++ b/recipes-debian/libcap/libcap_debian.bb
@@ -79,7 +79,7 @@ FILES_libpam-cap = " \
 "
 FILES_${PN}-dbg += "${base_libdir}/security/.debug/*.so"
 
-DEBIANNAME_${PN} = "${PN}2"
-DEBIANNAME_${PN}-bin = "${PN}2-bin"
+DEBIANNAME_${PN} = "${DPN}2"
+DEBIANNAME_${PN}-bin = "${DPN}2-bin"
 
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-debian/libcgroup/libcgroup_debian.bb
+++ b/recipes-debian/libcgroup/libcgroup_debian.bb
@@ -45,4 +45,4 @@ FILES_${PN}-dbg += "${base_libdir}/security/.debug"
 FILES_${PN}-dev += "${base_libdir}/security/*.la"
 
 # Rename package follow Debian
-DEBIANNAME_${PN} = "${PN}1"
+DEBIANNAME_${PN} = "${DPN}1"

--- a/recipes-debian/libcrypto++/libcrypto++_debian.bb
+++ b/recipes-debian/libcrypto++/libcrypto++_debian.bb
@@ -61,4 +61,4 @@ FILES_${PN}-utils = " \
     ${datadir}/crypto++/TestData \
 "
 
-DEBIANNAME_${PN}-dbg = "${PN}9-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}9-dbg"

--- a/recipes-debian/libdatrie/libdatrie_debian.bb
+++ b/recipes-debian/libdatrie/libdatrie_debian.bb
@@ -23,6 +23,6 @@ PACKAGES =+ "${PN}1-bin"
 FILES_${PN}1-bin += "${bindir}/*"
 
 # Rename package follow Debian
-DEBIANNAME_${PN} = "${PN}1"
+DEBIANNAME_${PN} = "${DPN}1"
 
 BBCLASSEXTEND += "native"

--- a/recipes-debian/libdshconfig/libdshconfig_debian.bb
+++ b/recipes-debian/libdshconfig/libdshconfig_debian.bb
@@ -16,4 +16,4 @@ DEBIAN_PATCH_TYPE = "nopatch"
 #configure follow debian/rules
 EXTRA_OECONF = "--with-versioned-symbol"
 
-DEBIANNAME_${PN}-dev = "${PN}1-dev"
+DEBIANNAME_${PN}-dev = "${DPN}1-dev"

--- a/recipes-debian/libevent/libevent_debian.bb
+++ b/recipes-debian/libevent/libevent_debian.bb
@@ -31,5 +31,5 @@ RDEPENDS_${PN}-extra = "${PN}-core"
 RDEPENDS_${PN}-openssl = "${PN}-core"
 RDEPENDS_${PN}-pthreads = "${PN}-core"
 
-DEBIANNAME_${PN}-dev = "${PN}-dev"
+DEBIANNAME_${PN}-dev = "${DPN}-dev"
 DEBIAN_NOAUTONAME_${PN}-dev = "1"

--- a/recipes-debian/libfs/libfs_debian.bb
+++ b/recipes-debian/libfs/libfs_debian.bb
@@ -18,4 +18,4 @@ inherit autotools distro_features_check pkgconfig
 
 REQUIRED_DISTRO_FEATURES = "x11"
 
-DEBIANNAME_${PN}-dbg = "${PN}6-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}6-dbg"

--- a/recipes-debian/libglu/libglu_debian.bb
+++ b/recipes-debian/libglu/libglu_debian.bb
@@ -31,7 +31,7 @@ inherit autotools distro_features_check pkgconfig
 # Requires libGL.so which is provided by mesa when x11 in DISTRO_FEATURES
 REQUIRED_DISTRO_FEATURES = "x11"
 
-DEBIANNAME_${PN} = "${PN}1-mesa"
-DEBIANNAME_${PN}-dev = "${PN}1-mesa-dev"
-RPROVIDES_${PN} += "${PN}-mesa"
-RPROVIDES_${PN}-dev += "${PN}-mesa-dev"
+DEBIANNAME_${PN} = "${DPN}1-mesa"
+DEBIANNAME_${PN}-dev = "${DPN}1-mesa-dev"
+RPROVIDES_${PN} += "${DPN}-mesa"
+RPROVIDES_${PN}-dev += "${DPN}-mesa-dev"

--- a/recipes-debian/libidn/libidn_debian.bb
+++ b/recipes-debian/libidn/libidn_debian.bb
@@ -40,7 +40,7 @@ PACKAGES =+ "idn"
 FILES_${PN} += "${libdir}"
 FILES_idn = "${bindir}/idn ${datadir}/emacs"
 
-DEBIANNAME_${PN}-dev = "${PN}11-dev"
+DEBIANNAME_${PN}-dev = "${DPN}11-dev"
 
 do_compile_prepend() {
         export LD_LIBRARY_PATH=${STAGING_LIBDIR}:$LD_LIBRARY_PATH

--- a/recipes-debian/libmongo-client/libmongo-client_debian.bb
+++ b/recipes-debian/libmongo-client/libmongo-client_debian.bb
@@ -25,4 +25,4 @@ do_install_append() {
 	chmod 0644 ${D}${libdir}/${LINKLIB}
 }
 #correct the sub-package name
-DEBIANNAME_${PN}-dbg = "${PN}0-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}0-dbg"

--- a/recipes-debian/libnet/libnet_debian.bb
+++ b/recipes-debian/libnet/libnet_debian.bb
@@ -26,6 +26,6 @@ DEPENDS = "libpcap"
 inherit autotools binconfig
 
 #Correct the packages name
-DEBIANNAME_${PN}-dev = "${PN}1-dev"
-DEBIANNAME_${PN}-doc = "${PN}1-doc"
-DEBIANNAME_${PN}-dbg = "${PN}1-dbg"
+DEBIANNAME_${PN}-dev = "${DPN}1-dev"
+DEBIANNAME_${PN}-doc = "${DPN}1-doc"
+DEBIANNAME_${PN}-dbg = "${DPN}1-dbg"

--- a/recipes-debian/libonig/libonig_debian.bb
+++ b/recipes-debian/libonig/libonig_debian.bb
@@ -21,6 +21,6 @@ SRC_URI += "file://do-not-use-system-headers.patch"
 
 inherit autotools binconfig
 
-DEBIANNAME_${PN}-dbg = "${PN}2-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}2-dbg"
 
 BBCLASSEXTEND = "native"

--- a/recipes-debian/libpcap/libpcap_debian.bb
+++ b/recipes-debian/libpcap/libpcap_debian.bb
@@ -54,8 +54,8 @@ do_install_prepend() {
 
 FILES_${PN}-dev += "${bindir}/pcap-config"
 
-DEBIANNAME_${PN} = "${PN}0.8"
-DEBIANNAME_${PN}-dev = "${PN}0.8-dev"
-DEBIANNAME_${PN}-dbg = "${PN}0.8-dbg"
+DEBIANNAME_${PN} = "${DPN}0.8"
+DEBIANNAME_${PN}-dev = "${DPN}0.8-dev"
+DEBIANNAME_${PN}-dbg = "${DPN}0.8-dbg"
 
 BBCLASSEXTEND="native"

--- a/recipes-debian/libproxy/libproxy_debian.bb
+++ b/recipes-debian/libproxy/libproxy_debian.bb
@@ -48,10 +48,10 @@ python() {
         d.setVar("EXTRA_OECMAKE", d.getVar("EXTRA_OECMAKE", False).replace("-DWITH_GNOME3=ON", "-DWITH_GNOME3=OFF -DWITH_GNOME=OFF"))
 }
 
-PACKAGES =+ "${PN}-tools ${PN}-plugin-gsettings python-${PN}"
+PACKAGES =+ "${PN}-tools ${DPN}-plugin-gsettings python-${PN}"
 
 FILES_${PN}-tools = "${bindir}/*"
-FILES_${PN}-plugin-gsettings = " \
+FILES_${DPN}-plugin-gsettings = " \
     ${libdir}/${DPN}/${SHLIBVER}/modules/config_gnome3.so \
     ${libdir}/${DPN}/${SHLIBVER}/pxgsettings \
 "
@@ -63,7 +63,7 @@ FILES_${PN}-dbg += " \
     ${libdir}/${DPN}/${SHLIBVER}/.debug \
 "
 
-RDEPENDS_${PN}-plugin-gsettings += "${PN}"
+RDEPENDS_${DPN}-plugin-gsettings += "${PN}"
 RDEPENDS_python-${PN} += "${PN}"
 
-DEBIANNAME_${PN}-plugin-gsettings = "${PN}1-plugin-gsettings"
+DEBIANNAME_${DPN}-plugin-gsettings = "${DPN}1-plugin-gsettings"

--- a/recipes-debian/libsamplerate/libsamplerate_debian.bb
+++ b/recipes-debian/libsamplerate/libsamplerate_debian.bb
@@ -22,8 +22,8 @@ inherit autotools-brokensep pkgconfig
 
 PACKAGES =+ "samplerate-programs"
 
-DEBIANNAME_${PN} = "${PN}0"
-DEBIANNAME_${PN}-dev = "${PN}0-dev"
+DEBIANNAME_${PN} = "${DPN}0"
+DEBIANNAME_${PN}-dev = "${DPN}0-dev"
 
 FILES_samplerate-programs = "${bindir}/sndfile-resample"
 RDEPENDS_${PN}-dev += "${PN}"

--- a/recipes-debian/libspiro/libspiro_debian.bb
+++ b/recipes-debian/libspiro/libspiro_debian.bb
@@ -13,6 +13,6 @@ LIC_FILES_CHKSUM = "file://gpl.txt;md5=751419260aa954499f7abaabaa882bbe"
 
 inherit autotools-brokensep
 
-DEBIANNAME_${PN}-dbg = "${PN}0-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}0-dbg"
 
 BBCLASSEXTEND = "native"

--- a/recipes-debian/libtasn1-6/libtasn1-6_debian.bb
+++ b/recipes-debian/libtasn1-6/libtasn1-6_debian.bb
@@ -27,5 +27,5 @@ do_install_append() {
 	chmod 0644 ${D}${libdir}/${LINKLIB}
 }
 inherit autotools texinfo binconfig lib_package
-DEBIANNAME_${PN}-dev = "${PN}-dev"
-DEBIANNAME_${PN}-dbg = "${PN}-dbg"
+DEBIANNAME_${PN}-dev = "${DPN}-dev"
+DEBIANNAME_${PN}-dbg = "${DPN}-dbg"

--- a/recipes-debian/libusb/libusb_debian.bb
+++ b/recipes-debian/libusb/libusb_debian.bb
@@ -26,12 +26,12 @@ do_install_append() {
 	rm ${D}${libdir}/*.la
 }
 
-PACKAGES =+ "${PN}++ ${PN}++-dev"
+PACKAGES =+ "${DPN}++ ${DPN}++-dev"
 
 FILES_${PN} += "${bindir}/libusb-config"
-FILES_${PN}++ = "${libdir}/libusbpp-*"
-FILES_${PN}++-dev = "${includedir}/usbpp.h ${libdir}/libusbpp.so"
+FILES_${DPN}++ = "${libdir}/libusbpp-*"
+FILES_${DPN}++-dev = "${includedir}/usbpp.h ${libdir}/libusbpp.so"
 
-DEBIANNAME_${PN} = "${PN}-0.1-4"
-DEBIANNAME_${PN}++ = "${PN}++-0.1-4c2"
-DEBIANNAME_${PN}++-dev = "${PN}++-dev"
+DEBIANNAME_${PN} = "${DPN}-0.1-4"
+DEBIANNAME_${DPN}++ = "${DPN}++-0.1-4c2"
+DEBIANNAME_${DPN}++-dev = "${DPN}++-dev"

--- a/recipes-debian/nfs-utils/libnfsidmap_debian.bb
+++ b/recipes-debian/nfs-utils/libnfsidmap_debian.bb
@@ -27,4 +27,4 @@ do_install_append(){
 FILES_${PN} += "${base_libdir}/${DPN}/*.so"
 FILES_${PN}-dbg += "${base_libdir}/${DPN}/.debug"
 
-DEBIANNAME_${PN} = "${PN}2"
+DEBIANNAME_${PN} = "${DPN}2"

--- a/recipes-debian/postgresql/postgresql_debian.bb
+++ b/recipes-debian/postgresql/postgresql_debian.bb
@@ -240,6 +240,6 @@ FILES_${PN}-dbg += "${libdir}/${NONARCH_PN}/${MAJOR_VER}/bin/.debug/* \
 
 DEBIANNAME_${PN} = "${DPN}"
 DEBIANNAME_${PN}-dbg = "${DPN}-dbg"
-DEBIANNAME_${PN}-doc = "${PN}-doc-${MAJOR_VER}"
+DEBIANNAME_${PN}-doc = "${DPN}-doc-${MAJOR_VER}"
 
 BBCLASSEXTEND = "native"

--- a/recipes-debian/semanage/libsemanage_debian.bb
+++ b/recipes-debian/semanage/libsemanage_debian.bb
@@ -80,6 +80,6 @@ FILES_${PN}-dbg += "${PYTHON_SITEPACKAGES_DIR}/.debug"
 
 RDEPENDS_${PN}_class-target += "${PN}-common"
 
-DEBIANNAME_${PN}-dev = "${PN}1-dev"
+DEBIANNAME_${PN}-dev = "${DPN}1-dev"
 
 BBCLASSEXTEND = "native"

--- a/recipes-debian/xorg-lib/libfontenc_debian.bb
+++ b/recipes-debian/xorg-lib/libfontenc_debian.bb
@@ -24,4 +24,4 @@ BBCLASSEXTEND = "native"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}1-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}1-dbg"

--- a/recipes-debian/xorg-lib/libice_debian.bb
+++ b/recipes-debian/xorg-lib/libice_debian.bb
@@ -28,4 +28,4 @@ BBCLASSEXTEND = "native"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}6-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}6-dbg"

--- a/recipes-debian/xorg-lib/libsm_debian.bb
+++ b/recipes-debian/xorg-lib/libsm_debian.bb
@@ -29,4 +29,4 @@ PV = "1.2.2"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}6-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}6-dbg"

--- a/recipes-debian/xorg-lib/libx11_debian.bb
+++ b/recipes-debian/xorg-lib/libx11_debian.bb
@@ -55,4 +55,4 @@ BBCLASSEXTEND = "native nativesdk"
 DEBIAN_PATCH_TYPE = "quilt"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}6-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}6-dbg"

--- a/recipes-debian/xorg-lib/libxau_debian.bb
+++ b/recipes-debian/xorg-lib/libxau_debian.bb
@@ -28,4 +28,4 @@ BBCLASSEXTEND = "native nativesdk"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}6-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}6-dbg"

--- a/recipes-debian/xorg-lib/libxcomposite_debian.bb
+++ b/recipes-debian/xorg-lib/libxcomposite_debian.bb
@@ -31,5 +31,5 @@ BBCLASSEXTEND = "native"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 #Correct package name folow Debian
-DEBIANNAME_${PN} = "${PN}1"
-DEBIANNAME_${PN}-dbg = "${PN}1-dbg"
+DEBIANNAME_${PN} = "${DPN}1"
+DEBIANNAME_${PN}-dbg = "${DPN}1-dbg"

--- a/recipes-debian/xorg-lib/libxcursor_debian.bb
+++ b/recipes-debian/xorg-lib/libxcursor_debian.bb
@@ -24,4 +24,4 @@ BBCLASSEXTEND = "native"
 
 DEBIAN_PATCH_TYPE = "quilt"
 
-DEBIANNAME_${PN}-dbg = "${PN}1-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}1-dbg"

--- a/recipes-debian/xorg-lib/libxdamage_debian.bb
+++ b/recipes-debian/xorg-lib/libxdamage_debian.bb
@@ -32,4 +32,4 @@ BBCLASSEXTEND = "native"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}1-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}1-dbg"

--- a/recipes-debian/xorg-lib/libxext_debian.bb
+++ b/recipes-debian/xorg-lib/libxext_debian.bb
@@ -30,4 +30,4 @@ BBCLASSEXTEND = "native nativesdk"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}6-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}6-dbg"

--- a/recipes-debian/xorg-lib/libxfixes_debian.bb
+++ b/recipes-debian/xorg-lib/libxfixes_debian.bb
@@ -26,4 +26,4 @@ BBCLASSEXTEND = "native nativesdk"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}3-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}3-dbg"

--- a/recipes-debian/xorg-lib/libxfont_debian.bb
+++ b/recipes-debian/xorg-lib/libxfont_debian.bb
@@ -26,4 +26,4 @@ BBCLASSEXTEND = "native"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}1-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}1-dbg"

--- a/recipes-debian/xorg-lib/libxft_debian.bb
+++ b/recipes-debian/xorg-lib/libxft_debian.bb
@@ -39,4 +39,4 @@ DPN = "xft"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}2-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}2-dbg"

--- a/recipes-debian/xorg-lib/libxi_debian.bb
+++ b/recipes-debian/xorg-lib/libxi_debian.bb
@@ -25,5 +25,5 @@ DEPENDS += "libxext inputproto libxfixes"
 # There is no debian patch
 DEBIAN_PATCH_TYPE = "nopatch"
 
-DEBIANNAME_${PN} = "${PN}6"
-DEBIANNAME_${PN}-dbg = "${PN}6-dbg"
+DEBIANNAME_${PN} = "${DPN}6"
+DEBIANNAME_${PN}-dbg = "${DPN}6-dbg"

--- a/recipes-debian/xorg-lib/libxinerama_debian.bb
+++ b/recipes-debian/xorg-lib/libxinerama_debian.bb
@@ -26,5 +26,5 @@ PROVIDES = "xinerama"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 # Correct the package name follow Debian
-DEBIANNAME_${PN} = "${PN}1"
-DEBIANNAME_${PN}-dbg = "${PN}1-dbg"
+DEBIANNAME_${PN} = "${DPN}1"
+DEBIANNAME_${PN}-dbg = "${DPN}1-dbg"

--- a/recipes-debian/xorg-lib/libxkbfile_debian.bb
+++ b/recipes-debian/xorg-lib/libxkbfile_debian.bb
@@ -24,5 +24,5 @@ BBCLASSEXTEND = "native"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 #Correct package name follow Debian
-DEBIANNAME_${PN} = "${PN}1"
-DEBIANNAME_${PN}-dbg = "${PN}1-dbg"
+DEBIANNAME_${PN} = "${DPN}1"
+DEBIANNAME_${PN}-dbg = "${DPN}1-dbg"

--- a/recipes-debian/xorg-lib/libxp_debian.bb
+++ b/recipes-debian/xorg-lib/libxp_debian.bb
@@ -15,7 +15,7 @@ CFLAGS_append += " -I ${S}/include/X11/XprintUtil -I ${S}/include/X11/extensions
 DEBIAN_PATCH_TYPE = "quilt"
 
 # Change package follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}6-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}6-dbg"
 
 EXTRA_OECONF += "--enable-static"
 

--- a/recipes-debian/xorg-lib/libxrandr_debian.bb
+++ b/recipes-debian/xorg-lib/libxrandr_debian.bb
@@ -27,5 +27,5 @@ BBCLASSEXTEND = "native nativesdk"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 #Correct the package name follow Debian
-DEBIANNAME_${PN}-dbg = "${PN}2-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}2-dbg"
 

--- a/recipes-debian/xorg-lib/libxrender_debian.bb
+++ b/recipes-debian/xorg-lib/libxrender_debian.bb
@@ -27,4 +27,4 @@ BBCLASSEXTEND = "native nativesdk"
 DEBIAN_PATCH_TYPE = "nopatch"
 
 #Correct package name follow Debian
-DEBIANNAME_{PN}-dbg = "${PN}1-dbg"
+DEBIANNAME_{PN}-dbg = "${DPN}1-dbg"

--- a/recipes-debian/xorg-lib/libxtst_debian.bb
+++ b/recipes-debian/xorg-lib/libxtst_debian.bb
@@ -26,4 +26,4 @@ PROVIDES = "xtst"
 DEBIAN_PATCH_TYPE = "quilt"
 
 # Correct the package name follow Debian.
-DEBIANNAME_${PN}-dbg = "${PN}6-dbg"
+DEBIANNAME_${PN}-dbg = "${DPN}6-dbg"

--- a/recipes-debian/zlib/zlib_debian.bb
+++ b/recipes-debian/zlib/zlib_debian.bb
@@ -43,11 +43,11 @@ do_install_append_class-target() {
 }
 
 # In Debian, binary package name of zlib is "${PN}1g"
-DEBIANNAME_${PN}-dbg       = "${PN}1g-dbg"
-DEBIANNAME_${PN}-staticdev = "${PN}1g-staticdev"
-DEBIANNAME_${PN}-dev       = "${PN}1g-dev"
-DEBIANNAME_${PN}-doc       = "${PN}1g-doc"
-DEBIANNAME_${PN}           = "${PN}1g"
+DEBIANNAME_${PN}-dbg       = "${DPN}1g-dbg"
+DEBIANNAME_${PN}-staticdev = "${DPN}1g-staticdev"
+DEBIANNAME_${PN}-dev       = "${DPN}1g-dev"
+DEBIANNAME_${PN}-doc       = "${DPN}1g-doc"
+DEBIANNAME_${PN}           = "${DPN}1g"
 
 BBCLASSEXTEND = "native nativesdk"
 


### PR DESCRIPTION
Use DPN variable when rename of packages, avoid duplicate
suffixes multilib's "lib64-" and "lib32-"