### PR TITLE
automake: fix race in parallel builds

### DIFF
--- a/recipes-debian/automake/automake_debian.bb
+++ b/recipes-debian/automake/automake_debian.bb
@@ -23,6 +23,7 @@ SRC_URI += " \
 	file://python-libdir.patch \
 	file://buildtest.patch \
 	file://automake-replace-w-option-in-shebangs-with-modern-use-warnings.patch \
+	file://0001-build-fix-race-in-parallel-builds.patch \
 "
 
 DEPENDS_class-native = "autoconf-native"


### PR DESCRIPTION
While native building, there is a parallel failure
[snip]
|: && mkdir -p doc && ./pre-inst-env /usr/bin/env perl
../automake-1.16.1/doc/help2man --output=doc/aclocal-1.16.1
aclocal-1.16
|help2man: can't get `--help' info from aclocal-1.16
|Try `--no-discard-stderr' if option outputs to stderr
Makefile:3693: recipe for target 'doc/aclocal-1.16.1' failed
[snip]

Correct Makefile rule to fix the issue

(From OE-Core rev: ef4907f311e3ddedfa3eb8a111cc1d146c19851a)