### PR TITLE
Fix libpam and fcode-utils compile error

### DIFF
--- a/recipes-debian/fcode-utils/fcode-utils_debian.bb
+++ b/recipes-debian/fcode-utils/fcode-utils_debian.bb
@@ -7,8 +7,10 @@ inherit debian-package
 require recipes-debian/sources/fcode-utils.inc
 DEBIAN_UNPACK_DIR = "${WORKDIR}/${BPN}"
 
+SRC_URI += "file://dont-strip-executable-file.patch"
+
 do_compile() {
-	oe_runmake
+	oe_runmake CC="${CC}"
 }
 
 do_install() {

--- a/recipes-debian/fcode-utils/files/dont-strip-executable-file.patch
+++ b/recipes-debian/fcode-utils/files/dont-strip-executable-file.patch
@@ -1,0 +1,21 @@
+[PATCH] fcode-utils: don't strip executables
+
+By default, fcode-utils strips its binaries. This produces QA ERROR
+as follows:
+
+   ERROR: QA Issue: File '/usr/bin/romheaders' from fcode-utils was already stripped, this will prevent future debugging! [already-stripped]
+
+Remove "strip" command in romheaders/Makefile to prevent the QA ERROR.
+
+diff --git a/romheaders/Makefile b/romheaders/Makefile
+index fa516f3..05985b1 100644
+--- a/romheaders/Makefile
++++ b/romheaders/Makefile
+@@ -32,7 +32,6 @@ all: romheaders
+ 
+ romheaders: $(SOURCES)
+ 	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(SOURCES) -o $@
+-	strip romheaders
+ 	
+ clean:
+ 	rm -f *~

--- a/recipes-debian/pam/files/fix-host-gcc-cant-recognized-option-fmacro-prefix-map.patch
+++ b/recipes-debian/pam/files/fix-host-gcc-cant-recognized-option-fmacro-prefix-map.patch
@@ -1,0 +1,19 @@
+Fix host gcc can't recognized option -fmacro-prefix-map
+
+The /doc/specs use CC_FOR_BUILD to compile a native binary, and
+the CFLAGS coming from the cross toolchain, containing
+the "-fmacro-prefix-map" default, so we should use the BUILD_CFLAGS, it
+contains the flags that used for host building.
+
+diff --git a/doc/specs/Makefile.am b/doc/specs/Makefile.am
+index b94e5ef..8efe975 100644
+--- a/doc/specs/Makefile.am
++++ b/doc/specs/Makefile.am
+@@ -12,6 +12,7 @@ draft-morgan-pam-current.txt: padout draft-morgan-pam.raw
+ AM_YFLAGS = -d
+ 
+ CC = @CC_FOR_BUILD@
++CFLAGS = @BUILD_CFLAGS@
+ AM_CPPFLAGS = @BUILD_CPPFLAGS@
+ AM_CFLAGS = @BUILD_CFLAGS@
+ AM_LDFLAGS = @BUILD_LDFLAGS@

--- a/recipes-debian/pam/libpam_debian.bb
+++ b/recipes-debian/pam/libpam_debian.bb
@@ -33,6 +33,7 @@ SRC_URI += " \
            file://libpam-xtests.patch \
            file://fixsepbuild.patch \
            file://crypt_configure.patch \
+           file://fix-host-gcc-cant-recognized-option-fmacro-prefix-map.patch \
           "
 
 SRC_URI_append_libc-musl = " file://0001-Add-support-for-defining-missing-funcitonality.patch \


### PR DESCRIPTION
Hi,

I created this pull request to improve fcode-utils and libpam recipes, please consider to apply it.

- fcode-utils: 

  - should be compile with CC=$CC to support for cross-compile
  - Don't strip executable file

- libpam: compile fail when host gcc version below 8.0, it can't recognized option -fmacro-prefix-map.
similar as issue: https://www.yoctoproject.org/pipermail/meta-virtualization/2019-February/004028.html