### PR TITLE
openssl: Add Ignore CVE list

### DIFF
--- a/recipes-debian/openssl/openssl_debian.bb
+++ b/recipes-debian/openssl/openssl_debian.bb
@@ -214,3 +214,5 @@ RREPLACES_openssl-conf = "openssl10-conf"
 RCONFLICTS_openssl-conf = "openssl10-conf"
 
 BBCLASSEXTEND = "native nativesdk"
+
+CVE_CHECK_WHITELIST = "CVE-2016-7798 CVE-2018-16395"


### PR DESCRIPTION
The cve-check task reports CVE-2016-7798 CVE-2018-16395 aren't fixed.

```
WARNING: openssl-1.1.1n-r0 do_cve_check: Found unpatched CVE (CVE-2016-7798 CVE-2018-16395), for more information check /home/masami/metadebian/build/tmp/work/aarch64-deby-linux/openssl/1.1.1n-r0/temp/cve.log
```

However, these CVEs are assigned to ruby openssl library.

- https://security-tracker.debian.org/tracker/CVE-2016-7798
- https://security-tracker.debian.org/tracker/CVE-2018-16395

So,  it's okay to ignore these CVEs in the openssl recipe.

Accroding to the NVE database, vendor ruby-lang , product openssl has these CVEs. It seems cve-check class checks product column but not checks vendor column.  

```
sqlite> .schema products
CREATE TABLE PRODUCTS (ID TEXT,         VENDOR TEXT, PRODUCT TEXT, VERSION_START TEXT, OPERATOR_START TEXT,         VERSION_END TEXT, OPERATOR_END TEXT);
CREATE INDEX PRODUCT_ID_IDX on PRODUCTS(ID);
sqlite> SELECT * FROM PRODUCTS WHERE ID IS "CVE-2016-7798";
CVE-2016-7798|ruby-lang|openssl|||2.0.0|<
CVE-2016-7798|debian|debian_linux|8.0|=||
CVE-2016-7798|debian|debian_linux|9.0|=||
sqlite> SELECT * FROM PRODUCTS WHERE ID IS "CVE-2018-16395";
CVE-2018-16395|ruby-lang|ruby|2.3.0|>=|2.3.7|<=
CVE-2018-16395|ruby-lang|ruby|2.4.0|>=|2.4.4|<=
CVE-2018-16395|ruby-lang|ruby|2.5.0|>=|2.5.1|<=
CVE-2018-16395|ruby-lang|ruby|2.6.0|=||
CVE-2018-16395|ruby-lang|ruby|2.6.0|=||
CVE-2018-16395|ruby-lang|openssl|||2.1.2|<
CVE-2018-16395|canonical|ubuntu_linux|16.04|=||
CVE-2018-16395|canonical|ubuntu_linux|18.10|=||
CVE-2018-16395|canonical|ubuntu_linux|14.04|=||
CVE-2018-16395|canonical|ubuntu_linux|18.04|=||
CVE-2018-16395|debian|debian_linux|8.0|=||
CVE-2018-16395|debian|debian_linux|9.0|=||
CVE-2018-16395|redhat|enterprise_linux|7.4|=||
```