### PR TITLE
Removed unnecessary MIRRORS variable to get source package from security.d.o

### DIFF
--- a/doc/6.security-update.md
+++ b/doc/6.security-update.md
@@ -44,7 +44,6 @@ DEBIAN_SRC_FORCE_REGEN = "1"
 
 DEBIAN_SECURITY_UPDATE_ENABLED = "1"
 DEBIAN_SECURITY_UPDATE_MIRROR = "http://security.debian.org/debian-security/pool/updates"
-MIRRORS+="${DEBIAN_MIRROR}    ${DEBIAN_SECURITY_UPDATE_MIRROR}"
 ```
 
 Then, run bitbake command e.g. bitbake -f core-image minimal -c clean.
@@ -93,5 +92,4 @@ Be careful, if package still use DEBIAN_SECURITY_UPDATE_MIRROR as a mirror serve
 
 ```
 DEBIAN_SECURITY_UPDATE_MIRROR = "http://security.debian.org/debian-security/pool/updates"
-MIRRORS+="${DEBIAN_MIRROR}    ${DEBIAN_SECURITY_UPDATE_MIRROR}"
 ```

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -168,5 +168,4 @@ function get_all_packages {
 
 function setup_security_update_repository() {
 	set_var "DEBIAN_SECURITY_UPDATE_MIRROR" "http://security.debian.org/debian-security/pool/updates" conf/local.conf
-	echo 'MIRRORS+="${DEBIAN_MIRROR}    ${DEBIAN_SECURITY_UPDATE_MIRROR}"' >> conf/local.conf
 }


### PR DESCRIPTION
The MIRRORS variable is not needed to get source package from
security.d.o. Therefore, removed it from document and common.sh.

I tested on local build and docker build.
