### PR TITLE
Morty: Fix boost, libpcap parallel build fail

### DIFF
--- a/recipes-debian/boost/boost_debian.bb
+++ b/recipes-debian/boost/boost_debian.bb
@@ -120,6 +120,13 @@ BJAM_TOOLS   = "-sTOOLS=gcc \
 
 # use PARALLEL_MAKE to speed up the build, but limit it by -j 64, greater paralelism causes bjam to segfault or to ignore -j
 # https://svn.boost.org/trac/boost/ticket/7634
+# However, sometimes the boost compile failed on some machines with a lot of CPU cores (eg: 32 threads):
+# > libs/math/build/../src/tr1/comp_ellint_2.cpp:7:0: error: unterminated #ifndef
+# > ....
+# > libs/math/build/../src/tr1/pch.hpp:1: confused by earlier errors, bailing out
+#
+# So temporarily limit the PARALLEL_MAKE by -j 16, this is not a solution but a workaround
+# to avoid both of errors above.
 def get_boost_parallel_make(bb, d):
     pm = d.getVar('PARALLEL_MAKE', True)
     if pm:
@@ -129,7 +136,7 @@ def get_boost_parallel_make(bb, d):
         pm_val = re.search("\d+", pm)
         if pm_prefix is None or pm_val is None:
             bb.error("Unable to analyse format of PARALLEL_MAKE variable: %s" % pm)
-        pm_nval = min(64, int(pm_val.group(0)))
+        pm_nval = min(16, int(pm_val.group(0)))
         return pm_prefix.group(0) + str(pm_nval) + pm[pm_val.end():]
     else:
         return ""

--- a/recipes-debian/libpcap/files/fix-parallel-make.patch
+++ b/recipes-debian/libpcap/files/fix-parallel-make.patch
@@ -1,0 +1,16 @@
+Sometimes libpcap cannot be built parallel,
+it will fail if the pcap_pic.o compiles before the version.h is generated
+
+diff --git a/Makefile.in b/Makefile.in
+index 0b39e48..48d29fb 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -92,7 +92,7 @@ YACC = @V_YACC@
+ 	@rm -f $@
+ 	$(CC) $(FULL_CFLAGS) -c -o $@ $(srcdir)/$*.c
+ 
+-%_pic.o: %.c
++%_pic.o: %.c version.h
+ 	@rm -f $@
+ 	$(CC) -fPIC $(FULL_CFLAGS) -c -o $@ $(srcdir)/$*.c
+ 

--- a/recipes-debian/libpcap/libpcap_debian.bb
+++ b/recipes-debian/libpcap/libpcap_debian.bb
@@ -22,6 +22,8 @@ PR = "r0"
 inherit debian-package
 PV = "1.6.2"
 
+SRC_URI += "file://fix-parallel-make.patch"
+
 BINCONFIG = "${bindir}/pcap-config"
 
 inherit autotools-brokensep bluetooth binconfig-disabled


### PR DESCRIPTION
Hi,

* Sometimes the boost compile failed on some machines with a lot of CPU cores,
Temporarily limit the PARALLEL_MAKE by -j 16, this is not a solution but a workaround to avoid error.
* libpcap compiles fail if the pcap_pic.o compiles before the version.h is generated,
correct jobs dependency to avoid parallel make fail.