### PR TITLE
syslog-ng: Fix license files settings.

### DIFF
--- a/recipes-debian/syslog-ng/syslog-ng_debian.bb
+++ b/recipes-debian/syslog-ng/syslog-ng_debian.bb
@@ -12,7 +12,12 @@ require recipes-debian/sources/syslog-ng.inc
 DEBIAN_UNPACK_DIR = "${WORKDIR}/syslog-ng-syslog-ng-${PV}"
 
 LICENSE = "GPL-2.0-with-OpenSSL-exception & LGPL-2.1-with-OpenSSL-exception"
-LIC_FILES_CHKSUM = "file://COPYING;md5=24c0c5cb2c83d9f2ab725481e4df5240"
+LIC_FILES_CHKSUM = " \
+  file://debian/copyright;md5=896b5aaa7720190a36f9383f1874258e \
+  file://LGPL.txt;md5=4fbd65380cdd255951079008b364516c \
+  file://GPL.txt;md5=133409beb2c017d3b0f406f22c5439e7 \
+"
+NO_GENERIC_LICENSE[LGPL-2.1-with-OpenSSL-exception] = "debian/copyright LGPL.txt"
 
 SRC_URI += " \
     file://configure.ac-add-option-enable-thread-tls-to-manage-.patch \


### PR DESCRIPTION
According to debian/copyright, syslog-ng is licensed under GPL-2+ with
OpenSSL exception and LGPL-2.1+ with OpenSSL exception. COPYING includes
neither descriptions about OpenSSL exception nor license text, so I
fixed LIC_FILES_CHKSUM to specify files including them. Also,
LGPL-2.1-with-OpenSSL-exception is not under meta/files/common-licenses
which causes below warning, I fixed to specify license files under ${S}.

```
syslog-ng-3.19.1-r0 do_populate_lic: syslog-ng: No generic license file exists for: LGPL-2.1-with-OpenSSL-exception in any provider
```