### PR TITLE
gcc: Add CVE-2021-37322 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/gcc/gcc-8.inc
+++ b/recipes-debian/gcc/gcc-8.inc
@@ -56,3 +56,6 @@ SRC_URI += " \
        file://0037-Fix-for-testsuite-failure.patch \
        file://0038-Re-introduce-spe-commandline-options.patch \
 "
+
+# CVE-2021-37322 is already fixed but NVD db is not updated.
+CVE_CHECK_WHITELIST = "CVE-2021-37322"


### PR DESCRIPTION
CVE-2021-37322 is labeled as vulnerability of gcc on the NVD information.
https://nvd.nist.gov/vuln/detail/CVE-2021-37322
But this is labeled as vulnerability of binutils on Debian security tracker.
https://security-tracker.debian.org/tracker/CVE-2021-37322

This is because same module is used on both packages.
As for debian based system, real installed module is made from binutils.
And CVE-2021-37322 was fixed on binutils package and same fixed code could be found on gcc package.
So we add CVE-2021-37322 to CVE_CHECK_WHITELIST of gcc.