### PR TITLE
gzip: fix gzip ptest failure

### DIFF
--- a/recipes-debian/gzip/gzip_debian.bb
+++ b/recipes-debian/gzip/gzip_debian.bb
@@ -36,4 +36,6 @@ do_install_ptest() {
 	    -e 's:${HOSTTOOLS_DIR}/::g'                 \
 	    -e 's:${BASE_WORKDIR}/${MULTIMACH_TARGET_SYS}::g' \
 	    ${B}/tests/Makefile > ${D}${PTEST_PATH}/src/tests/Makefile
+	chmod 755 ${D}${PTEST_PATH}/src/tests/zgrep-abuse
+	chmod 755 ${D}${PTEST_PATH}/src/tests/zgrep-binary
 }


### PR DESCRIPTION
zgrep-abuse and zgrep-binary files aren't set executable bit that causes ptest failure.

zgrep-abuse and zgrep-binary tests failed 

```
FAIL: zgrep-abuse
FAIL: zgrep-binary
>>> snip <<<
============================================================================                                                                                                                                                                  
Testsuite summary for gzip 1.9
============================================================================                                           
# TOTAL: 23
# PASS:  19
# SKIP:  2
# XFAIL: 0                                                                                                             
# FAIL:  2
# XPASS: 0                                                                                                             
# ERROR: 0     
```

Set executable bit fixes ptest failure.

```
PASS: zgrep-abuse
PASS: zgrep-binary
>>> snip <<<
============================================================================
Testsuite summary for gzip 1.9
============================================================================
# TOTAL: 23
# PASS:  21
# SKIP:  2
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```