### PR TITLE
tar: Add some CVEs to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/tar/tar_debian.bb
+++ b/recipes-debian/tar/tar_debian.bb
@@ -72,3 +72,5 @@ PROVIDES_append_class-native = " tar-replacement-native"
 NATIVE_PACKAGE_PATH_SUFFIX = "/${PN}"
 
 BBCLASSEXTEND = "native nativesdk"
+
+CVE_PRODUCT = "gnu:tar"


### PR DESCRIPTION
We add following CVE to CVE_CHECK_WHITELIST.
CVE-2021-32803
CVE-2021-32804
CVE-2021-37701
CVE-2021-37712
CVE-2021-37713

Because these are not CVE of GNU tar but CVE of Node-tar.