### PR TITLE
Morty/bind, curl: fix errors after upgrading the version

### DIFF
--- a/recipes-debian/bind/bind.inc
+++ b/recipes-debian/bind/bind.inc
@@ -6,7 +6,7 @@
 SUMMARY = "ISC Internet Domain Name Server"
 HOMEPAGE = "http://www.isc.org/sw/bind/"
 
-INC_PR = "r0"
+INC_PR = "r1"
 DPN = "bind9"
 inherit debian-package
 PV = "9.9.5.dfsg"
@@ -15,7 +15,7 @@ LICENSE = "ISC & BSD"
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=a3df5f651469919a0e6cb42f84fb6ff1"
 
 DEPENDS = "openssl libcap krb5"
-DEBIAN_PATCH_TYPE = "nopatch"
+DEBIAN_PATCH_TYPE = "quilt"
 
 # fix-configure-for-gssapi.patch 
 #	fix path to gssapi.h file

--- a/recipes-debian/curl/curl_debian.bb
+++ b/recipes-debian/curl/curl_debian.bb
@@ -5,13 +5,13 @@
 
 require curl.inc
 
-PR = "${INC_PR}.0"
+PR = "${INC_PR}.1"
 
 inherit binconfig
 
-PACKAGECONFIG ??= "${@bb.utils.contains("DISTRO_FEATURES", "ipv6", "ipv6", "", d)} gnutls zlib"
-PACKAGECONFIG_class-native = "ipv6 ssl zlib"
-PACKAGECONFIG_class-nativesdk = "ipv6 ssl zlib"
+PACKAGECONFIG ??= "${@bb.utils.contains("DISTRO_FEATURES", "ipv6", "ipv6", "", d)} gnutls zlib libssh2"
+PACKAGECONFIG_class-native = "ipv6 ssl zlib libssh2"
+PACKAGECONFIG_class-nativesdk = "ipv6 ssl zlib libssh2"
 
 PACKAGECONFIG[ipv6] = "--enable-ipv6,--disable-ipv6,"
 PACKAGECONFIG[ssl] = "--with-ssl --with-random=/dev/urandom,--without-ssl,openssl"

--- a/recipes-debian/libgcrypt/libgcrypt_debian.bb
+++ b/recipes-debian/libgcrypt/libgcrypt_debian.bb
@@ -80,4 +80,4 @@ DEBIANNAME_${PN}-dev = "libgcrypt20-dev"
 DEBIANNAME_${PN}-dbg = "libgcrypt20-dbg"
 DEBIANNAME_${PN}-doc = "libgcrypt20-doc"
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-debian/libgpg-error/libgpg-error_debian.bb
+++ b/recipes-debian/libgpg-error/libgpg-error_debian.bb
@@ -57,4 +57,4 @@ do_install_append() {
 
 FILES_${PN}-dev += "${bindir}/gpg-error"
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-debian/libssh2/libssh2_debian.bb
+++ b/recipes-debian/libssh2/libssh2_debian.bb
@@ -1,0 +1,31 @@
+SUMMARY = "SSH2 client-side library"
+DESCRIPTION = "libssh2 is a client-side C library implementing the SSH2 protocol. \
+ It supports regular terminal, SCP and SFTP (v1-v5) sessions; \
+ port forwarding, X11 forwarding; password, key-based and \
+ keyboard-interactive authentication."
+HOMEPAGE = "http://libssh2.org/"
+
+inherit debian-package
+PV = "1.4.3"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d00afe44f336a79a2ca7e1681ce14509 \
+"
+
+inherit autotools
+
+DEPENDS += "zlib"
+
+# only one of openssl and gcrypt could be set
+PACKAGECONFIG ??= "gcrypt"
+PACKAGECONFIG[openssl] = "--with-openssl --with-libssl-prefix=${STAGING_LIBDIR},--without-openssl,openssl"
+PACKAGECONFIG[gcrypt] = "--with-libgcrypt --with-libgcrypt-prefix=${STAGING_EXECPREFIXDIR},--without-libgcrypt,libgcrypt"
+
+DEBIANNAME_${PN}-dev = "${DPN}-1-dev"
+RPROVIDES_${PN}-dev = "${DPN}-1-dev"
+
+do_install_append() {
+	# remove redundant file
+	rm -rf ${D}${libdir}/libssh2.la
+}
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Hi, I created this pull request to update _bind_ and _curl_ recipes.

- **bind**: some patches and series are added into _debian/patches_ in _9.9.5.dfsg-9+deb8u28_, so _DEBIAN_PATCH_TYPE_ needs to be set to "quilt"
- **curl**: after upgrading to _7.38.0-4+deb8u26_, _curl_ requires _libssh2_ package. So we need create new recipe for _libssh2_ and correct the dependency for _curl_ package.