### PR TITLE
ninja: Add CVE-2021-4336 to CVE_CHECK_WHITELIST

### DIFF
--- a/recipes-debian/ninja/ninja_debian.bb
+++ b/recipes-debian/ninja/ninja_debian.bb
@@ -27,3 +27,6 @@ do_install() {
 }
 
 BBCLASSEXTEND = "native nativesdk"
+
+# This is a different Ninja
+CVE_CHECK_WHITELIST += "CVE-2021-4336"


### PR DESCRIPTION
CVE-2021-4336 is `monitor-ninja` issue, not `ninja` in this recipe.  
Therefore, add CVE-2021-4336 to CVE_CHECK_WHITELIST of ninja.

https://nvd.nist.gov/vuln/detail/CVE-2021-4336
https://security-tracker.debian.org/tracker/CVE-2021-4336

# Testing
## How to test
Test in Deby's docker environment.
```
meta-debian$ cd docker/
meta-debian/docker$ make start
```
Set up build environment.
```
deby@38025a708d1c:~$ source poky/meta-debian/tests/common.sh
deby@38025a708d1c:~$ setup_builddir
deby@38025a708d1c:~/build$ echo 'MACHINE = "qemuarm64"' >> ./conf/local.conf
deby@38025a708d1c:~/build$ echo 'DISTRO = "deby"' >> ./conf/local.conf
deby@38025a708d1c:~/build$ echo 'INHERIT += "cve-check debian-cve-check"' >> ./conf/local.conf
```

## CVE check 
### Before
CVE check log before applying this patch.
```
deby@38025a708d1c:~/build$ bitbake ninja -c cve_check
Parsing recipes: 100% |#########################################################################################################################################################| Time: 0:00:27
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1821 targets, 57 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:8b22728a5a3f172e3e8ae156bde46c7cb5bb51a6"

Initialising tasks: 100% |######################################################################################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: ninja-1.8.2-r0 do_cve_check: Found unpatched CVE (CVE-2021-4336), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/ninja/1.8.2-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

### After
CVE check log after applying this patch.
```
deby@f78884fa7189:~/build$ bitbake ninja -c cve_check
Parsing recipes: 100% |#########################################################################################################################################################| Time: 0:00:39
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1821 targets, 57 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "add-CVE-2021-4336-to-whitelist:345d7772f32bf1912b4530d026a50de1b5b764eb"

Initialising tasks: 100% |######################################################################################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.
```