### PR TITLE
docker: Change volume directory's owner from root to deby

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,10 @@ RUN echo "$USER:$PASS" | chpasswd
 RUN echo "%$USER  ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/debygrp
 RUN chmod 0440 /etc/sudoers.d/debygrp
 
+# Setup directory's owner before switching to user.
+RUN mkdir $HOME/downloads
+RUN chown $USER:$USER $HOME/downloads
+
 ADD gitproxy /usr/bin
 RUN chmod +x /usr/bin/gitproxy
 RUN bash -c 'if test -n "$http_proxy"; then sed -i -e "s#\(http_proxy=\"\).*#\1$http_proxy\"#" /usr/bin/gitproxy; fi'


### PR DESCRIPTION
The docker's volume directory is mounted with owner root.  
By creating an empty directory and setting the owner before mounting,  
the directory will be mounted with the set owner.

# Testing
## Reproduction steps
1. Delete all deby's docker objects.
```
docker rm <CONTAINER-ID>
docker image rm <IMAGE-ID>
docker volume rm docker_downloads
```

2. Start docker.
```
cd ./meta-debian/docker
make start
```

3. Check volume directory's owner mounted within docker container.
The volume directory is /home/deby/downloads/.
```
ls -la /home/deby/build/downloads
ls -lad /home/deby/downloads/
```

## Result log
### Before
The volume directory owner is root.
```
deby@70b9d0d27ee9:~$ ls -la /home/deby/build/downloads
lrwxrwxrwx 1 deby deby 20 Aug  8 02:47 /home/deby/build/downloads -> /home/deby/downloads
deby@70b9d0d27ee9:~$ ls -lad /home/deby/downloads/
drwxr-xr-x 2 root root 4096 Aug  9 03:09 /home/deby/downloads/
```

### After
By applying this patch, the volume directory will be owned by deby.
```
deby@f7236ada2fb5:~$ ls -la /home/deby/build/downloads
lrwxrwxrwx 1 deby deby 20 Aug  9 01:08 /home/deby/build/downloads -> /home/deby/downloads
deby@f7236ada2fb5:~$ ls -lad /home/deby/downloads/
drwxr-xr-x 2 deby deby 4096 Aug  9 00:59 /home/deby/downloads/
```