### PR TITLE
Fix ptest fails caused by inability to resolve localhost name.

### DIFF
--- a/recipes-debian/glib-2.0/glib-2.0_debian.bb
+++ b/recipes-debian/glib-2.0/glib-2.0_debian.bb
@@ -22,3 +22,5 @@ SRC_URI += " \
     file://glib-meson.cross \
 "
 SRC_URI_append_class-natve = "file://relocate-modules.patch"
+
+RDEPENDS_${PN}-ptest += "netbase"

--- a/recipes-debian/netbase/netbase_debian.bb
+++ b/recipes-debian/netbase/netbase_debian.bb
@@ -25,3 +25,32 @@ do_install () {
 }
 
 CONFFILES_${PN} = "${sysconfdir}/hosts"
+
+# Base on debian/netbase.postinst
+pkg_postinst_${PN}() {
+    create_hosts_file() {
+        if [ -e $D${sysconfdir}/hosts ]; then return 0; fi
+
+        cat > $D${sysconfdir}/hosts <<-EOF
+	127.0.0.1	localhost
+	::1		localhost ip6-localhost ip6-loopback
+	ff02::1		ip6-allnodes
+	ff02::2		ip6-allrouters
+
+EOF
+    }
+
+    create_networks_file() {
+        if [ -e $D${sysconfdir}/networks ]; then return 0; fi
+
+        cat > $D${sysconfdir}/networks <<-EOF
+	default		0.0.0.0
+	loopback	127.0.0.0
+	link-local	169.254.0.0
+
+EOF
+    }
+
+    create_hosts_file
+    create_networks_file
+}

--- a/recipes-debian/openssh/openssh_debian.bb
+++ b/recipes-debian/openssh/openssh_debian.bb
@@ -150,7 +150,7 @@ FILES_${PN}-keygen = "${bindir}/ssh-keygen"
 RDEPENDS_${PN} += "${PN}-scp ${PN}-ssh ${PN}-sshd ${PN}-keygen"
 RDEPENDS_${PN}-sshd += "${PN}-keygen ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'pam-plugin-keyinit pam-plugin-loginuid', '', d)}"
 RRECOMMENDS_${PN}-sshd_append_class-target = " rng-tools"
-RDEPENDS_${PN}-ptest += "${PN}-sftp ${PN}-misc ${PN}-sftp-server make sed sudo coreutils"
+RDEPENDS_${PN}-ptest += "${PN}-sftp ${PN}-misc ${PN}-sftp-server make sed sudo coreutils netbase"
 
 RPROVIDES_${PN}-ssh = "ssh"
 RPROVIDES_${PN}-sshd = "sshd"

--- a/recipes-debian/python/python3_debian.bb
+++ b/recipes-debian/python/python3_debian.bb
@@ -299,7 +299,7 @@ FILES_${PN}-misc = "${libdir}/python${PYTHON_MAJMIN} ${libdir}/python${PYTHON_MA
 PACKAGES += "${PN}-man"
 FILES_${PN}-man = "${datadir}/man"
 
-RDEPENDS_${PN}-ptest = "${PN}-modules ${PN}-tests unzip bzip2 libgcc tzdata-europe coreutils sed"
+RDEPENDS_${PN}-ptest = "${PN}-modules ${PN}-tests unzip bzip2 libgcc tzdata-europe coreutils sed netbase"
 RDEPENDS_${PN}-ptest_append_libc-glibc = " locale-base-tr-tr.iso-8859-9"
 RDEPENDS_${PN}-tkinter += "${@bb.utils.contains('PACKAGECONFIG', 'tk', 'tk tk-lib', '', d)}"
 RDEPENDS_${PN}-dev = ""

--- a/recipes-debian/python/python_debian.bb
+++ b/recipes-debian/python/python_debian.bb
@@ -186,7 +186,7 @@ FILES_${PN}-misc = "${libdir}/python${PYTHON_MAJMIN}"
 RDEPENDS_${PN}-modules += "${PN}-misc"
 
 # ptest
-RDEPENDS_${PN}-ptest = "${PN}-modules ${PN}-tests unzip tzdata-europe coreutils sed"
+RDEPENDS_${PN}-ptest = "${PN}-modules ${PN}-tests unzip tzdata-europe coreutils sed netbase"
 RDEPENDS_${PN}-tkinter += "${@bb.utils.contains('PACKAGECONFIG', 'tk', 'tk', '', d)}"
 # catch manpage
 PACKAGES += "${PN}-man"


### PR DESCRIPTION
Ptests for some packages fail because they cannot resolve the localhost name.
See [issue#332](https://github.com/meta-debian/meta-debian/issues/332)

Fixed follows for resolve that issue:
- netbase: Install /etc/hosts and /etc/networks
  Add the pkg_postinst_${PN}() function to netbase recipe.
- Add netbase to RDEPENDS for ptest
  For following packages:
  - openssh
  - python3
  - python
  - glib-2.0

# Testing
## Prepare testing
Modify local tests/qemu_ptest.sh file.
1. (optional) Add archive repositories to MIRRORS
   ```diff
   @@ -47,6 +47,11 @@ if [ "$TEST_ENABLE_SECURITY_UPDATE" = "1" ]; then
           setup_security_update_repository
    fi
    
   +# (optional) Add MIRRORS
   +echo 'MIRRORS += "${DEBIAN_SECURITY_UPDATE_MIRROR} https://snapshot.debian.org/archive/debian-security/20230920T232020Z/pool/updates/ \n"' >> conf/local.conf
   +echo 'MIRRORS += "${DEBIAN_SECURITY_UPDATE_MIRROR} https://snapshot.debian.org/archive/debian-security/20231010T220613Z/pool/updates/ \n"' >> conf/local.conf
   +echo 'MIRRORS += "${DEBIAN_SECURITY_UPDATE_MIRROR} https://snapshot.debian.org/archive/debian-security/20231218T230659Z/pool/updates/ \n"' >> conf/local.conf
   +
    # Enable ptest
    append_var "DISTRO_FEATURES_append" " ptest" conf/local.conf
    append_var "EXTRA_IMAGE_FEATURES_append" " ptest-pkgs" conf/local.conf
   ```
2. Check for additional files (/etc/hosts, /etc/networks)
   ```diff
   @@ -128,6 +133,12 @@ for distro in $TEST_DISTROS; do
                           fi
                   done
    
   +               # Check files
   +               ssh_qemu "echo 'cat /etc/hosts'"
   +               ssh_qemu "cat /etc/hosts"
   +               ssh_qemu "echo 'cat /etc/networks'"
   +               ssh_qemu "cat /etc/networks"
   +
                   # Run ptest
                   scp_qemu $THISDIR/run_ptest.sh $TEST_USER@$TEST_IPADDR:/tmp/ > /dev/null
                   ssh_qemu "VERBOSE=$VERBOSE PTEST_RUNNER_TIMEOUT='$PTEST_RUNNER_TIMEOUT' TEST_PACKAGES='$TEST_PACKAGES' $EXTRA_ENV /tmp/run_ptest.sh"
   ```

# How to test
Set the environment variables and run qemu_ptest.
```
export TEST_ENABLE_SECURITY_UPDATE="1"
export TEST_PACKAGES="openssh python3 python glib-2.0"
export TEST_DISTROS="deby"
export TEST_MACHINES="qemuarm64"
export COMPOSE_HTTP_TIMEOUT=7200
export PTEST_RUNNER_TIMEOUT=7200
export TEST_DISTRO_FEATURES="pam"
export QEMU_PARAMS="-smp 4 -m 8192"
export IMAGE_ROOTFS_EXTRA_SPACE=2097152
cd ./docker/
make qemu_ptest
```

## Test result
The /etc/hosts and /etc/networks files are existing, and the ptest results for each package have improved compared to before this PR.
```
docker$ make qemu_ptest
docker-compose run --rm qemu_ptest
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: openssh python3 python glib-2.0
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: Set IMAGE_ROOTFS_EXTRA_SPACE to 2097152 KB.
Parsing recipes: 100% |################################################################################################################################| Time: 0:00:30
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1821 targets, 58 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-ptest-fails-by-localhost:8f595f9c98d8cc7ffafa50f873f3f3b5165f0307"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |#############################################################################################################################| Time: 0:00:01
Sstate summary: Wanted 852 Found 0 Missed 852 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: ncurses-native-6.1+20181013-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/n/ncurses/ncurses_6.1+20181013-2+deb10u4.dsc;name=ncurses_6.1+20181013-2+deb10u4.dsc, attempting MIRRORS if available
WARNING: python3-native-3.7.3-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/p/python3.7/python3.7_3.7.3-2+deb10u5.dsc;name=python3.7_3.7.3-2+deb10u5.dsc, attempting MIRRORS if available
WARNING: python3-native-3.7.3-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/p/python3.7/python3.7_3.7.3-2+deb10u5.debian.tar.xz;name=python3.7_3.7.3-2+deb10u5.debian.tar.xz, attempting MIRRORS if available
WARNING: ncurses-native-6.1+20181013-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/n/ncurses/ncurses_6.1+20181013-2+deb10u4.debian.tar.xz;name=ncurses_6.1+20181013-2+deb10u4.debian.tar.xz, attempting MIRRORS if available
WARNING: dbus-native-1.12.24-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/d/dbus/dbus_1.12.24-0+deb10u1.dsc;name=dbus_1.12.24-0+deb10u1.dsc, attempting MIRRORS if available
WARNING: nss-native-3.42.1-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/n/nss/nss_3.42.1-1+deb10u6.dsc;name=nss_3.42.1-1+deb10u6.dsc, attempting MIRRORS if available
WARNING: dbus-native-1.12.24-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/d/dbus/dbus_1.12.24-0+deb10u1.debian.tar.xz;name=dbus_1.12.24-0+deb10u1.debian.tar.xz, attempting MIRRORS if available
WARNING: nss-native-3.42.1-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/n/nss/nss_3.42.1-1+deb10u6.debian.tar.xz;name=nss_3.42.1-1+deb10u6.debian.tar.xz, attempting MIRRORS if available
WARNING: glib-2.0-native-2.58.3-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/g/glib2.0/glib2.0_2.58.3-2+deb10u4.dsc;name=glib2.0_2.58.3-2+deb10u4.dsc, attempting MIRRORS if available
WARNING: glib-2.0-native-2.58.3-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/g/glib2.0/glib2.0_2.58.3-2+deb10u4.debian.tar.xz;name=glib2.0_2.58.3-2+deb10u4.debian.tar.xz, attempting MIRRORS if available
WARNING: qemu-native-3.1-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/q/qemu/qemu_3.1+dfsg-8+deb10u10.dsc;name=qemu_3.1+dfsg-8+deb10u10.dsc, attempting MIRRORS if available
WARNING: qemu-native-3.1-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/q/qemu/qemu_3.1+dfsg-8+deb10u10.debian.tar.xz;name=qemu_3.1+dfsg-8+deb10u10.debian.tar.xz, attempting MIRRORS if available
WARNING: openssh-7.9p1-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/o/openssh/openssh_7.9p1-10+deb10u3.dsc;name=openssh_7.9p1-10+deb10u3.dsc, attempting MIRRORS if available
WARNING: tzdata-2021a-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/t/tzdata/tzdata_2021a-0+deb10u11.dsc;name=tzdata_2021a-0+deb10u11.dsc, attempting MIRRORS if available
WARNING: tzdata-2021a-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/t/tzdata/tzdata_2021a-0+deb10u11.debian.tar.xz;name=tzdata_2021a-0+deb10u11.debian.tar.xz, attempting MIRRORS if available
WARNING: curl-native-7.64.0-r1 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/c/curl/curl_7.64.0-4+deb10u7.dsc;name=curl_7.64.0-4+deb10u7.dsc, attempting MIRRORS if available
WARNING: curl-native-7.64.0-r1 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/c/curl/curl_7.64.0-4+deb10u7.debian.tar.xz;name=curl_7.64.0-4+deb10u7.debian.tar.xz, attempting MIRRORS if available
NOTE: Tasks Summary: Attempted 2962 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 17 WARNING messages shown.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams="-smp 4 -m 8192"`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (5s / 60s)
NOTE: Waiting for SSH to be ready... (10s / 60s)
NOTE: Waiting for SSH to be ready... (15s / 60s)
NOTE: Waiting for SSH to be ready... (20s / 60s)
stdin: is not a tty
cat /etc/hosts
stdin: is not a tty
127.0.0.1	localhost
::1		localhost ip6-localhost ip6-loopback
ff02::1		ip6-allnodes
ff02::2		ip6-allrouters

stdin: is not a tty
cat /etc/networks
stdin: is not a tty
default		0.0.0.0
loopback	127.0.0.0
link-local	169.254.0.0

stdin: is not a tty
Running ptest for openssh ...
openssh: PASS/SKIP/FAIL = 66/7/0
Running ptest for python3 ...
python3: PASS/SKIP/FAIL = 30483/1198/11
Running ptest for python ...
python: PASS/SKIP/FAIL = 408/42/15
Running ptest for glib-2.0 ...
glib-2.0: PASS/SKIP/FAIL = 244/0/4
stdin: is not a tty
```

For reference, the results before this PR:
```
stdin: is not a tty
cat /etc/hosts
stdin: is not a tty
cat: /etc/hosts: No such file or directory
stdin: is not a tty
cat /etc/networks
stdin: is not a tty
cat: /etc/networks: No such file or directory
stdin: is not a tty
Running ptest for openssh ...
openssh: PASS/SKIP/FAIL = 35/7/1
Running ptest for python3 ...
python3: PASS/SKIP/FAIL = 4676/70/87
Running ptest for python ...
python: PASS/SKIP/FAIL = 287/30/17
Running ptest for glib-2.0 ...
glib-2.0: PASS/SKIP/FAIL = 244/0/4
stdin: is not a tty
```
