### PR TITLE
zlib: Set CVE_PRODUCT

### DIFF
--- a/recipes-debian/zlib/zlib_debian.bb
+++ b/recipes-debian/zlib/zlib_debian.bb
@@ -19,6 +19,8 @@ LIC_FILES_CHKSUM = " \
 file://zlib.h;beginline=4;endline=23;md5=627e6ecababe008a45c70e318ae7014e \
 "
 
+CVE_PRODUCT = "zlib:zlib"
+
 SRC_URI += "file://ldflags-tests.patch \
             file://run-ptest \
 "


### PR DESCRIPTION
Currently, cve_check finds CVE-2023-6992 as unpatched CVE of zlib. However, the CVE is for Cloudflare version of zlib. 

Setting CVE_PRODUCT prevents this type of false-positive.

## How to test

To perform cve_check, I added the following to `conf/local.conf`:
```
MACHINE = "qemuarm64"
INHERIT += "cve-check debian-cve-check"
```

Before this commit, cve_check showed the following warning:
```
$ bitbake zlib -c cve_check

*snip*

WARNING: zlib-1.2.11-r0 do_cve_check: Found unpatched CVE (CVE-2023-45853 CVE-2023-6992), for more information check /home/miyazaki/Projects/workspace/build/tmp-glibc/work/aarch64-emlinux-linux/zlib/1.2.11-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

After this commit, CVE-2023-6992 is not shown:
```
$ bitbake zlib -c cve_check

*snip*

WARNING: zlib-1.2.11-r0 do_cve_check: Found unpatched CVE (CVE-2023-45853), for more information check /home/miyazaki/Projects/workspace/build/tmp-glibc/work/aarch64-emlinux-linux/zlib/1.2.11-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown
```