### PR TITLE
attr: Add ptest

### DIFF
--- a/recipes-debian/attr/attr/run-ptest
+++ b/recipes-debian/attr/attr/run-ptest
@@ -1,0 +1,2 @@
+#!/bin/sh
+make -k check-TESTS

--- a/recipes-debian/attr/attr_debian.bb
+++ b/recipes-debian/attr/attr_debian.bb
@@ -15,7 +15,9 @@ LIC_FILES_CHKSUM = "file://doc/COPYING;md5=2d0aa14b3fce4694e4f615e30186335f \
 inherit debian-package
 require recipes-debian/sources/attr.inc
 
-inherit autotools gettext update-alternatives
+SRC_URI += "file://run-ptest"
+
+inherit ptest autotools gettext update-alternatives
 
 BBCLASSEXTEND = "native nativesdk"
 
@@ -24,3 +26,37 @@ ALTERNATIVE_${PN} = "setfattr"
 ALTERNATIVE_TARGET[setfattr] = "${bindir}/setfattr"
 
 PACKAGES =+ "lib${BPN}"
+
+do_install_ptest() {
+        cp ${B}/Makefile ${D}${PTEST_PATH}
+        sed -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
+            -e 's|${DEBUG_PREFIX_MAP}||g' \
+            -e 's:${HOSTTOOLS_DIR}/::g' \
+            -e 's:${RECIPE_SYSROOT_NATIVE}::g' \
+            -e 's:${BASE_WORKDIR}/${MULTIMACH_TARGET_SYS}::g' \
+            -i ${D}${PTEST_PATH}/Makefile
+
+        sed -i "s|^srcdir =.*|srcdir = \.|g" ${D}${PTEST_PATH}/Makefile
+        sed -i "s|^top_srcdir =.*|top_srcdir = \.|g" ${D}${PTEST_PATH}/Makefile
+        sed -i "s|^abs_srcdir =.*|abs_srcdir = \.|g" ${D}${PTEST_PATH}/Makefile
+        sed -i "s|^abs_top_srcdir =.*|abs_top_srcdir = \.|g" ${D}${PTEST_PATH}/Makefile
+        sed -i "s|^Makefile:.*|Makefile:|g" ${D}${PTEST_PATH}/Makefile
+        cp -rf ${S}/build-aux/ ${D}${PTEST_PATH}
+        cp -rf ${S}/test/ ${D}${PTEST_PATH}
+}
+
+RDEPENDS_${PN}-ptest = "attr \
+                        bash \
+                        coreutils \
+                        perl-module-constant \
+                        perl-module-filehandle \
+                        perl-module-getopt-std \
+                        perl-module-posix \
+                        make \
+                        perl \
+                        gawk \
+                        perl-module-cwd \
+                        perl-module-file-basename \
+                        perl-module-file-path \
+                        perl-module-file-spec \
+                        "


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of attr package based on the following recipe:

* base recipe: [meta/recipes-support/attr/attr_2.5.1.bb](https://git.yoctoproject.org/poky/tree/meta/recipes-support/attr/attr_2.5.1.bb?id=3e50e45917831d9da2d86e69fb908a1a78483b62)
* base branch: master
* base commit: 3e50e45917831d9da2d86e69fb908a1a78483b62

# Note

In this PR I rewrite `run-ptest` because the original `run-ptest` of the reference recipe cannot be run twice or more.

```
root@qemuarm64:~# ptest-runner attr
START: ptest-runner
2023-12-20T07:23
BEGIN: /usr/lib/attr/ptest
...(snip)...
END: /usr/lib/attr/ptest
2023-12-20T07:24
STOP: ptest-runner
root@qemuarm64:~# ptest-runner attr
START: ptest-runner
2023-12-20T07:24
BEGIN: /usr/lib/attr/ptest
make: 'test-suite.log' is up to date.
DURATION: 0
END: /usr/lib/attr/ptest
2023-12-20T07:24
STOP: ptest-runner
```

# Test
## How to test

1. Enable ptest and install attr package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " attr"
EOS
```

2. Build core-image-minimal

```
$ bitbake core-image-minimal
```

3. Run qemu and run ptest of attr

```
$ runqemu nographic
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner attr
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner attr
START: ptest-runner
2024-04-08T08:11
BEGIN: /usr/lib/attr/ptest
make[1]: Entering directory '/usr/lib/attr/ptest'
[   36.356364] random: run: uninitialized urandom read (4 bytes read)
[   39.873245] random: sort-getfattr-o: uninitialized urandom read (4 bytes read)
[   40.193713] random: sort-getfattr-o: uninitialized urandom read (4 bytes read)
[   40.435489] random: sort-getfattr-o: uninitialized urandom read (4 bytes read)
[   40.983604] random: sort-getfattr-o: uninitialized urandom read (4 bytes read)
[   41.714681] random: sort-getfattr-o: uninitialized urandom read (4 bytes read)
PASS: test/attr.test
PASS: test/root/getfattr.test
============================================================================
Testsuite summary for attr 2.4.48
============================================================================
# TOTAL: 2
# PASS:  2
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[1]: Leaving directory '/usr/lib/attr/ptest'
DURATION: 17
END: /usr/lib/attr/ptest
2024-04-08T08:12
STOP: ptest-runner
# ptest-runner attr
START: ptest-runner
2024-04-08T08:12
BEGIN: /usr/lib/attr/ptest
make[1]: Entering directory '/usr/lib/attr/ptest'
PASS: test/attr.test
PASS: test/root/getfattr.test
============================================================================
Testsuite summary for attr 2.4.48
============================================================================
# TOTAL: 2
# PASS:  2
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[1]: Leaving directory '/usr/lib/attr/ptest'
DURATION: 16
END: /usr/lib/attr/ptest
2024-04-08T08:12
STOP: ptest-runner
# ptest-runner attr
START: ptest-runner
2024-04-08T08:12
BEGIN: /usr/lib/attr/ptest
make[1]: Entering directory '/usr/lib/attr/ptest'
PASS: test/attr.test
PASS: test/root/getfattr.test
============================================================================
Testsuite summary for attr 2.4.48
============================================================================
# TOTAL: 2
# PASS:  2
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[1]: Leaving directory '/usr/lib/attr/ptest'
DURATION: 17
END: /usr/lib/attr/ptest
2024-04-08T08:12
STOP: ptest-runner
```

[ptest-attr.log](https://github.com/ml-ichiro/meta-debian/files/14902860/ptest-attr.log)

## Test summary

* TOTAL: 2
  * PASS: 2
  * FAIL: 0

I run this ptest 3 times and obtained the same results.