### PR TITLE
libpam: Add ptest

### DIFF
--- a/recipes-debian/pam/files/run-ptest
+++ b/recipes-debian/pam/files/run-ptest
@@ -1,0 +1,32 @@
+#! /bin/sh
+
+cd tests
+
+export srcdir=.
+
+failed=0
+all=0
+for f in tst-*; do
+    "./$f" > /dev/null 2>&1
+    case "$?" in
+        0)
+            echo "PASS: $f"
+            all=$((all + 1))
+            ;;
+        77)
+            echo "SKIP: $f"
+            ;;
+        *)
+            echo "FAIL: $f"
+            failed=$((failed + 1))
+            all=$((all + 1))
+            ;;
+    esac
+done
+
+if [ "$failed" -eq 0 ] ; then
+  echo "All $all tests passed"
+else
+  echo "$failed of $all tests failed"
+fi
+unset srcdir


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of libpam package based on the following recipe:

* base recipe: [meta/recipes-extended/pam/libpam_1.5.3.bb](https://git.yoctoproject.org/poky/tree/meta/recipes-extended/pam/libpam_1.5.3.bb?id=3e50e45917831d9da2d86e69fb908a1a78483b62)
* base branch: master
* base commit: 3e50e45917831d9da2d86e69fb908a1a78483b62

# Test
## How to test

1. Enable ptest and install libpam package

NOTE: `pam` DISTRO_FEATURES is required to use libpam package.

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest pam"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " libpam"
EOS
```

3. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

4. Run qemu and execute ptest of libpam

```
$ runqemu nographic
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner libpam
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
libpam  /usr/lib/libpam/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t 3600 libpam
START: ptest-runner
2024-04-09T04:41
BEGIN: /usr/lib/libpam/ptest
PASS: tst-pam_acct_mgmt
PASS: tst-pam_authenticate
PASS: tst-pam_chauthtok
PASS: tst-pam_close_session
PASS: tst-pam_end
PASS: tst-pam_fail_delay
PASS: tst-pam_get_item
PASS: tst-pam_get_user
PASS: tst-pam_getenvlist
PASS: tst-pam_mkargv
PASS: tst-pam_open_session
PASS: tst-pam_set_data
PASS: tst-pam_set_item
PASS: tst-pam_setcred
PASS: tst-pam_start
All 15 tests passed
DURATION: 1
END: /usr/lib/libpam/ptest
2024-04-09T04:41
STOP: ptest-runner
```

[ptest-libpam.log](https://github.com/meta-debian/meta-debian/files/14913538/ptest-libpam.log)

## Test summary

* TOTAL: 15
  * PASS: 15
  * FAIL: 0

I executed this ptest 3 times and obtained the same results.