### PR TITLE
python2.7: Fix issue that incorrect counts in ptest results

### DIFF
--- a/recipes-debian/python/python/run-ptest
+++ b/recipes-debian/python/python/run-ptest
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python -mtest -W | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -r -e '/\.\.\. (ERROR|FAIL)/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'
+python -m test -v | sed -u -e '/\.\.\. ok/ s/^/PASS: /g' -r -e '/\.\.\. (ERROR|FAIL)/ s/^/FAIL: /g' -e '/\.\.\. skipped/ s/^/SKIP: /g' -e 's/ \.\.\. ok//g' -e 's/ \.\.\. ERROR//g' -e 's/ \.\.\. FAIL//g' -e 's/ \.\.\. skipped//g'


### PR DESCRIPTION
# Purpose of pull request

The ptest in python 2.7 had a problem with the test module argument, incorrectly counted ptest results.
Prior to this patch, only re-run results of failed test items were counted, by specifying -W argument to test module.

So, fix test module argument.

# Test
Run ptest of python package on docker of meta-debian

## How to run ptest of python package
1. (Optional) Add MIRRORS if necessary
2. Prepare environment variables
3. Run ptest on docker of meta-debian

### (Optional) Add MIRRORS if necessary
Add MIRRORS to tests/qemu_ptest.sh:
```diff
@@ -47,6 +47,8 @@ if [ "$TEST_ENABLE_SECURITY_UPDATE" = "1" ]; then
        setup_security_update_repository
 fi
 
+echo 'MIRRORS += "${DEBIAN_SECURITY_UPDATE_MIRROR} https://snapshot.debian.org/archive/debian-security/20240315T162427Z/pool/updates/ \n"' >> conf/local.conf
+
 # Enable ptest
 append_var "DISTRO_FEATURES_append" " ptest" conf/local.conf
 append_var "EXTRA_IMAGE_FEATURES_append" " ptest-pkgs" conf/local.conf
```

### Prepare environment variables
```
$ export TEST_PACKAGES="python"
$ export TEST_DISTROS="deby"
$ export TEST_MACHINES="qemuarm64"
$ export COMPOSE_HTTP_TIMEOUT=7200
$ export PTEST_RUNNER_TIMEOUT=7200
$ export QEMU_PARAMS="-smp 4 -m 8192"
$ export IMAGE_ROOTFS_EXTRA_SPACE=2097152
```

### Run ptest on docker of meta-debian
```
$ cd ./meta-debian/docker/
$ make qemu_ptest
```

## Run ptest result
The counting of test items number is clearly improved.
- before: `python: PASS/SKIP/FAIL = 408/42/15`
- after: `python: PASS/SKIP/FAIL = 16473/742/13`

```
meta-debian/docker$ make qemu_ptest
docker-compose run --rm qemu_ptest
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_ENABLE_SECURITY_UPDATE variable is not set. Defaulting to a blank string.
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: python
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: Set IMAGE_ROOTFS_EXTRA_SPACE to 4194304 KB.
Parsing recipes: 100% |#################################################################################################| Time: 0:00:31
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 58 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-python-ptest-arg:bdd070f9ee64f1ee13490943b1c5fef9087d3088"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 846 Found 0 Missed 846 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: python3-native-3.7.3-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/p/python3.7/python3.7_3.7.3-2+deb10u6.debian.tar.xz;name=python3.7_3.7.3-2+deb10u6.debian.tar.xz, attempting MIRRORS if available
WARNING: python-native-2.7.16-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/p/python2.7/python2.7_2.7.16-2+deb10u3.dsc;name=python2.7_2.7.16-2+deb10u3.dsc, attempting MIRRORS if available
WARNING: curl-native-7.64.0-r1 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/c/curl/curl_7.64.0-4+deb10u8.dsc;name=curl_7.64.0-4+deb10u8.dsc, attempting MIRRORS if available
WARNING: curl-native-7.64.0-r1 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/c/curl/curl_7.64.0-4+deb10u8.debian.tar.xz;name=curl_7.64.0-4+deb10u8.debian.tar.xz, attempting MIRRORS if available
NOTE: Tasks Summary: Attempted 2949 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 4 WARNING messages shown.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams="-smp 4 -m 8192"`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (5s / 60s)
NOTE: Waiting for SSH to be ready... (10s / 60s)
NOTE: Waiting for SSH to be ready... (15s / 60s)
stdin: is not a tty
Running ptest for python ...
python: PASS/SKIP/FAIL = 16473/742/13
stdin: is not a tty
```
```
meta-debian/docker$ tail -n 30 ../tests/logs/deby/qemuarm64/python.ptest.log 
== Tests result: FAILURE ==

352 tests OK.

6 tests failed:
    test_distutils test_ensurepip test_import test_minidom test_site
    test_ssl

47 tests skipped:
    test_aepack test_al test_applesingle test_bsddb185 test_bsddb3
    test_cd test_cl test_codecmaps_cn test_codecmaps_hk
    test_codecmaps_jp test_codecmaps_kr test_codecmaps_tw test_curses
    test_dl test_gdb test_gl test_idle test_imageop test_imgfile
    test_kqueue test_linuxaudiodev test_macos test_macostools
    test_msilib test_nis test_ossaudiodev test_pep277 test_py3kwarn
    test_scriptpackages test_smtpnet test_socketserver test_sqlite
    test_startfile test_sunaudiodev test_tcl test_timeout test_tk
    test_tools test_ttk_guionly test_ttk_textonly test_turtle
    test_unicode_file test_urllib2net test_urllibnet test_winreg
    test_winsound test_zipfile64
8 skips unexpected on linux2:
    test_gdb test_idle test_tcl test_tk test_tools test_ttk_guionly
    test_ttk_textonly test_turtle

Total duration: 1 hour 8 min
Tests result: FAILURE
DURATION: 4091
END: /usr/lib/python/ptest
2024-04-11T08:36
STOP: ptest-runner
```