### PR TITLE
lzo: Fix installation path to run ptest 

### DIFF
--- a/recipes-debian/lzo/lzo_debian.bb
+++ b/recipes-debian/lzo/lzo_debian.bb
@@ -6,8 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://src/lzo_init.c;beginline=5;endline=25;md5=9ae697ca01829b0a383c5d2d163e0108"
 
 inherit debian-package
-BPN = "lzo2"
-require recipes-debian/sources/${BPN}.inc
+require recipes-debian/sources/lzo2.inc
 DEBIAN_UNPACK_DIR = "${WORKDIR}/lzo-${PV}"
 FILESEXTRAPATHS =. "${FILE_DIRNAME}/lzo:${COREBASE}/meta/recipes-support/lzo/lzo/:"
 


### PR DESCRIPTION
# Purpose of pull request
The 'ptest-runner lzo' command is cannot execute ptest, because the run-ptest file of the lzo-ptest package install to /usr/lib/lzo2/ptest/run-ptest.

So, fix recipe to correct installation path of run-ptest file.

# Test
Run ptest of python package on docker of meta-debian

## How to run ptest of python package
1. (Optional) Add MIRRORS if necessary
2. Prepare environment variables
3. Run ptest on docker of meta-debian

### (Optional) Add MIRRORS if necessary
Add MIRRORS to tests/qemu_ptest.sh:
```diff
@@ -47,6 +47,8 @@ if [ "$TEST_ENABLE_SECURITY_UPDATE" = "1" ]; then
        setup_security_update_repository
 fi
 
+echo 'MIRRORS += "${DEBIAN_SECURITY_UPDATE_MIRROR} https://snapshot.debian.org/archive/debian-security/20240315T162427Z/pool/updates/ \n"' >> conf/local.conf
+
 # Enable ptest
 append_var "DISTRO_FEATURES_append" " ptest" conf/local.conf
 append_var "EXTRA_IMAGE_FEATURES_append" " ptest-pkgs" conf/local.conf
```

### Prepare environment variables
```
$ export TEST_PACKAGES="lzo"
$ export TEST_DISTROS="deby"
$ export TEST_MACHINES="qemuarm64"
$ export COMPOSE_HTTP_TIMEOUT=7200
$ export PTEST_RUNNER_TIMEOUT=7200
```

### Run ptest on docker of meta-debian
```
$ cd ./meta-debian/docker/
$ make qemu_ptest
```

## Run ptest result
The ptest is running, and all passed.
- before: `ptest for lzo isn't available. Skip.`
- after: `lzo: PASS/SKIP/FAIL = 5/0/0`

```
meta-debian/docker$ make qemu_ptest
docker-compose run --rm qemu_ptest
WARN[0000] The "QEMU_PARAMS" variable is not set. Defaulting to a blank string. 
WARN[0000] The "IMAGE_ROOTFS_EXTRA_SPACE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_DISTRO_FEATURES" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_ENABLE_SECURITY_UPDATE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_DISTRO_FEATURES" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_ENABLE_SECURITY_UPDATE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_ENABLE_SECURITY_UPDATE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_DISTRO_FEATURES" variable is not set. Defaulting to a blank string. 
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: lzo
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
Parsing recipes: 100% |####################################################################################################| Time: 0:00:52
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 67 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-lzo-ptest-can-executing:40de4cd72e72c085d0c578b6c8ee727404d1b086"

Initialising tasks: 100% |#################################################################################################| Time: 0:00:03
Sstate summary: Wanted 818 Found 0 Missed 818 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2858 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams=""`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (5s / 60s)
NOTE: Waiting for SSH to be ready... (10s / 60s)
NOTE: Waiting for SSH to be ready... (15s / 60s)
NOTE: Waiting for SSH to be ready... (20s / 60s)
NOTE: Waiting for SSH to be ready... (25s / 60s)
stdin: is not a tty
Running ptest for lzo ...
lzo: PASS/SKIP/FAIL = 5/0/0
stdin: is not a tty
```

For reference, before update log:
```
meta-debian/docker$ make qemu_ptest 
docker-compose run --rm qemu_ptest
WARNING: The QEMU_PARAMS variable is not set. Defaulting to a blank string.
WARNING: The IMAGE_ROOTFS_EXTRA_SPACE variable is not set. Defaulting to a blank string.
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_ENABLE_SECURITY_UPDATE variable is not set. Defaulting to a blank string.
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: lzo
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
Parsing recipes: 100% |#################################################################################################| Time: 0:00:33
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 58 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:add051995f162aed76d6fecc363bc0dc9df4934d"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 832 Found 0 Missed 832 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: python3-native-3.7.3-r0 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/p/python3.7/python3.7_3.7.3-2+deb10u6.debian.tar.xz;name=python3.7_3.7.3-2+deb10u6.debian.tar.xz, attempting MIRRORS if available
WARNING: curl-native-7.64.0-r1 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/c/curl/curl_7.64.0-4+deb10u8.dsc;name=curl_7.64.0-4+deb10u8.dsc, attempting MIRRORS if available
WARNING: curl-native-7.64.0-r1 do_fetch: Failed to fetch URL http://security.debian.org/debian-security/pool/updates/main/c/curl/curl_7.64.0-4+deb10u8.debian.tar.xz;name=curl_7.64.0-4+deb10u8.debian.tar.xz, attempting MIRRORS if available
NOTE: Tasks Summary: Attempted 2902 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 3 WARNING messages shown.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams=""`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (5s / 60s)
NOTE: Waiting for SSH to be ready... (10s / 60s)
NOTE: Waiting for SSH to be ready... (15s / 60s)
stdin: is not a tty
ptest for lzo isn't available. Skip.
stdin: is not a tty
```