### PR TITLE
pixman: Add CVE-2023-37769 to whitelist

### DIFF
--- a/recipes-debian/xorg-lib/pixman_debian.bb
+++ b/recipes-debian/xorg-lib/pixman_debian.bb
@@ -38,3 +38,6 @@ SRC_URI += "\
 "
 
 REQUIRED_DISTRO_FEATURES = ""
+
+# CVE-2023-37769: This is for test program (stress-test) and it's not distributed by binary package.
+CVE_CHECK_WHITELIST = "CVE-2023-37769"


### PR DESCRIPTION
# Purpose of pull request

CVE-2023-37769 is for test program (stress-test) and it is not distributed by binary package.
So, add it to CVE_CHECK_WHITELIST.

# Test
## How to test

Add following line into conf/local.conf.

```
INHERIT += "cve-check"
```

And then run following command.

```
$ bitbake pixman -c cve_check
```

## Test result

Before this commit, it showed the following warning:

```
$ bitbake pixman -c cve_check
...(snip)...
WARNING: pixman-0.36.0-r0 do_cve_check: Found unpatched CVE (CVE-2022-44638 CVE-2023-37769), for more information check /home/miracle/work/emlinux-2.9-202405/build-qemuarm64/tmp-glibc/work/aarch64-emlinux-linux/pixman/0.36.0-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

After this commit, CVE-2023-37769 is not shown:

```
$ bitbake pixman -c cve_check
...(snip)...
WARNING: pixman-0.36.0-r0 do_cve_check: Found unpatched CVE (CVE-2022-44638), for more information check /home/miracle/work/emlinux-2.9-202405/build-qemuarm64/tmp-glibc/work/aarch64-emlinux-linux/pixman/0.36.0-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```