### PR TITLE
Add ptest for curl 

### DIFF
--- a/recipes-debian/curl/curl/0001-tests-runtests.pl-Backport-commits-related-to-gettin.patch
+++ b/recipes-debian/curl/curl/0001-tests-runtests.pl-Backport-commits-related-to-gettin.patch
@@ -1,0 +1,61 @@
+From b6d3a52e6c6106df860bb49f3b389a7ce831f4b2 Mon Sep 17 00:00:00 2001
+From: Takahiro Terada <takahiro.terada@miraclelinux.com>
+Date: Thu, 25 Apr 2024 19:35:37 +0900
+Subject: [PATCH] tests/runtests.pl: Backport commits related to getting test
+ numbers
+
+The test suite of curl runs test numbers retrieved by get_disttests function in
+runtest.pl. Previously, the test numbers were retrieved using make command
+within that function. In curl-master [1], improved to parse Makefile.inc file.
+
+So backport the following commits related to test numbers:
+  - 3c0f4622c runtests: parse data/Makefile.inc instead of using make
+  - dd47b0cce runtests: also find the last test in Makefile.inc
+  - 2cb0eaba7 runtests.pl: tolerate test directories without Makefile.inc
+
+[1] https://github.com/curl/curl.git
+
+Signed-off-by: Takahiro Terada <takahiro.terada@miraclelinux.com>
+---
+ tests/runtests.pl | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/tests/runtests.pl b/tests/runtests.pl
+index 6c8b903..3b790cc 100755
+--- a/tests/runtests.pl
++++ b/tests/runtests.pl
+@@ -519,10 +519,19 @@ sub checkcmd {
+ #######################################################################
+ # Get the list of tests that the tests/data/Makefile.am knows about!
+ #
+-my $disttests;
++my $disttests = "";
+ sub get_disttests {
+-    my @dist = `cd data && make show`;
+-    $disttests = join("", @dist);
++    # If a non-default $TESTDIR is being used there may not be any
++    # Makefile.inc in which case there's nothing to do.
++    open(D, "<$TESTDIR/Makefile.inc") or return;
++    while(<D>) {
++        chomp $_;
++        if(($_ =~ /^#/) ||($_ !~ /test/)) {
++            next;
++        }
++        $disttests .= join("", $_);
++    }
++    close(D);
+ }
+ 
+ #######################################################################
+@@ -3221,7 +3230,7 @@ sub singletest {
+     # timestamp test preparation start
+     $timeprepini{$testnum} = Time::HiRes::time() if($timestats);
+ 
+-    if($disttests !~ /test$testnum\W/ ) {
++    if($disttests !~ /test$testnum(\W|\z)/ ) {
+         logmsg "Warning: test$testnum not present in tests/data/Makefile.inc\n";
+     }
+     if($disabled{$testnum}) {
+-- 
+2.25.1
+

--- a/recipes-debian/curl/curl/disable-tests
+++ b/recipes-debian/curl/curl/disable-tests
@@ -1,0 +1,30 @@
+# These CRL test (alt-avc) are failing
+356
+412
+413
+# These CRL tests are scanning docs
+971
+1119
+1132
+1135
+# These CRL tests are scnning headers
+1167
+# These CRL tests are scanning man pages
+1139
+1140
+1173
+1177
+# This CRL test is looking for m4 files
+1165
+# This CRL test is looking for src files
+1185
+# This test is scanning the source tree
+1222
+# These CRL tests need --libcurl option to be enabled
+1400
+1401
+1402
+1403
+1404
+1405
+1465

--- a/recipes-debian/curl/curl/run-ptest
+++ b/recipes-debian/curl/curl/run-ptest
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cd tests
+
+# Run all tests, don't stop on first failure
+# Don't use valgrind if it is found
+# Use automake-style output
+# Print log output on failure
+# Don't run the flaky tests
+./runtests.pl -a -n -am -p '!flaky'

--- a/recipes-debian/curl/curl_debian.bb
+++ b/recipes-debian/curl/curl_debian.bb
@@ -21,9 +21,11 @@ CVE_CHECK_WHITELIST = "CVE-2021-22926"
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
     file://temporary-workaround-for-build-error-in-7.64.0-4+deb10u8.patch \
+    file://run-ptest \
+    file://disable-tests \
 "
 
-inherit autotools pkgconfig binconfig multilib_header
+inherit autotools pkgconfig binconfig multilib_header ptest
 
 PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'ipv6', d)} gnutls proxy threaded-resolver zlib"
 PACKAGECONFIG_class-native = "ipv6 proxy ssl threaded-resolver zlib"
@@ -74,6 +76,28 @@ do_install_append_class-target() {
 	    -e 's|${DEBUG_PREFIX_MAP}||g' \
 	    ${D}${bindir}/curl-config
 }
+
+do_compile_ptest() {
+        oe_runmake -C ${B}/tests
+}
+
+do_install_ptest() {
+        cat  ${WORKDIR}/disable-tests >> ${S}/tests/data/DISABLED
+        rm -f ${B}/tests/configurehelp.pm
+        cp -rf ${B}/tests ${D}${PTEST_PATH}
+        rm -f ${D}${PTEST_PATH}/tests/libtest/.libs/libhostname.la
+        rm -f ${D}${PTEST_PATH}/tests/libtest/libhostname.la
+        mv ${D}${PTEST_PATH}/tests/libtest/.libs/* ${D}${PTEST_PATH}/tests/libtest/
+        mv ${D}${PTEST_PATH}/tests/libtest/libhostname.so ${D}${PTEST_PATH}/tests/libtest/.libs/
+        cp -rf ${S}/tests ${D}${PTEST_PATH}
+        find ${D}${PTEST_PATH}/ -type f -name Makefile.am -o -name Makefile.in -o -name Makefile -delete
+        install -d ${D}${PTEST_PATH}/src
+        ln -sf ${bindir}/curl   ${D}${PTEST_PATH}/src/curl
+        cp -rf ${D}${bindir}/curl-config ${D}${PTEST_PATH}
+}
+
+RDEPENDS_${PN}-ptest += "bash perl-modules"
+RDEPENDS_${PN}-ptest_append_libc-glibc = " locale-base-en-us"
 
 PACKAGES =+ "lib${BPN}"
 

--- a/recipes-debian/curl/curl_debian.bb
+++ b/recipes-debian/curl/curl_debian.bb
@@ -23,6 +23,7 @@ SRC_URI += " \
     file://temporary-workaround-for-build-error-in-7.64.0-4+deb10u8.patch \
     file://run-ptest \
     file://disable-tests \
+    file://0001-tests-runtests.pl-Backport-commits-related-to-gettin.patch \
 "
 
 inherit autotools pkgconfig binconfig multilib_header ptest


### PR DESCRIPTION
# Purpose of pull request

Add ptest referenced from Poky-master:
- a0b379f  curl: Add ptest support

And, fix ptest run:
- cb28364  curl: Add patch to improve ptest run

# Test
Run ptest of curl package on docker of meta-debian

## How to run ptest of tar package
1. Prepare environment variables
   ```
   export TEST_PACKAGES="curl"
   export TEST_DISTROS="deby"
   export TEST_MACHINES="qemuarm64"
   export COMPOSE_HTTP_TIMEOUT=7200
   export PTEST_RUNNER_TIMEOUT=7200
   export QEMU_PARAMS="-smp 4 -m 8192"
   ```

2. Run ptest on docker of meta-debian
   ```
   cd docker
   make qemu_ptest
   ```

## Test result
Some tests have failed, but most have passed.
```
meta-debian/docker$ make qemu_ptest 
docker-compose run --rm qemu_ptest
WARN[0000] The "IMAGE_ROOTFS_EXTRA_SPACE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_ENABLE_SECURITY_UPDATE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_DISTRO_FEATURES" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_ENABLE_SECURITY_UPDATE" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_DISTRO_FEATURES" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_DISTRO_FEATURES" variable is not set. Defaulting to a blank string. 
WARN[0000] The "TEST_ENABLE_SECURITY_UPDATE" variable is not set. Defaulting to a blank string. 
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: curl
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
Parsing recipes: 100% |#################################################################################################| Time: 0:01:16
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 67 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "add-curl-ptest:cb283640ed4075e1e55a0f0cb33d23b3c7735e77"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:02
Sstate summary: Wanted 848 Found 0 Missed 848 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2950 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams="-smp 4 -m 8192"`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (6s / 60s)
NOTE: Waiting for SSH to be ready... (11s / 60s)
NOTE: Waiting for SSH to be ready... (16s / 60s)
NOTE: Waiting for SSH to be ready... (21s / 60s)
stdin: is not a tty
Running ptest for curl ...
curl: PASS/SKIP/FAIL = 746/0/3
stdin: is not a tty
```

```
meta-debian/docker$ tail ../tests/logs/deby/qemuarm64/curl.ptest.log 
=== End of file trace2081
TESTDONE: 746 tests out of 749 reported OK: 99%
TESTFAIL: These test cases failed: 8 1221 2081 
TESTDONE: 1249 tests were considered during 474 seconds.

ERROR: Exit status is 256
DURATION: 482
END: /usr/lib/curl/ptest
2024-05-15T07:22
STOP: ptest-runner
```
