### PR TITLE
Change the source URL of CVE information json data to Freexian

### DIFF
--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -49,7 +49,7 @@ python update_dst () {
     import shutil
     from datetime import datetime, date
 
-    json_url = "https://security-tracker.debian.org/tracker/data/json"
+    json_url = "https://deb.freexian.com/extended-lts/tracker/data/json"
     dist_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True),"dst.json")
     dist_dir = os.path.dirname(dist_path)
 

--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -47,6 +47,7 @@ python update_dst () {
     """
     import urllib.request
     import shutil
+    import time
     from datetime import datetime, date
 
     json_url = "https://deb.freexian.com/extended-lts/tracker/data/json"
@@ -61,9 +62,19 @@ python update_dst () {
         if timestamp.date() == date.today():
             return
 
-    with urllib.request.urlopen(json_url) as response, open(dist_path, 'wb') as f:
-        shutil.copyfileobj(response, f)
-    bb.debug(2, "DST database updated")
+    for attempt in range(5):
+        try:
+            with urllib.request.urlopen(json_url) as response, open(dist_path, 'wb') as f:
+                shutil.copyfileobj(response, f)
+            bb.debug(2, "DST database updated")
+            return
+        except Exception as e:
+            bb.debug(2, "DST database: received error (%s), retrying" % (e))
+            time.sleep(attempt * 3)
+            continue
+    else:
+        bb.error("DST database received error")
+        return
 }
 
 do_populate_cve_db[postfuncs] += "update_dst"

--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -93,7 +93,9 @@ def deb_check_cves(d, pkg_data):
     
     debian_codename = d.getVar("DEBIAN_CODENAME", True)
     for cve in pkg_data.keys():
-        cve_data = pkg_data[cve]["releases"][debian_codename]
+        cve_data = pkg_data.get(cve, {}).get("releases", {}).get(debian_codename)
+        if cve_data is None:
+            continue
         # if the status is "open" or "undetermined", the cve treat as unpatched
         if cve_data["status"] != "resolved":
             unpatched.append(cve)


### PR DESCRIPTION
# Purpose of pull request
Debian releases will be provided with long-term extended support by Freexian.
So, change the source URL of CVE information json data to Freexian.

See: https://www.freexian.com/lts/extended/

And fixed the following issues:
- [d3c9b00](https://github.com/meta-debian/meta-debian/pull/349/commits/d3c9b00d02406b48a5a86153e90f19754e70c099) debian-cve-check.bbclass: Fix "Exception: KeyError: 'buster'"
- [435cd60](https://github.com/meta-debian/meta-debian/pull/349/commits/435cd601f58b5c7b6a4d532a86fa5cca669ec4df) debian-cve-check.bbclass: Add retry if connection to json_url fails

# Test
## How to test
Generates CVE information for each version before and after this patch is applied.
Alternatively, it can be used as "before version" without [1944e10](https://github.com/meta-debian/meta-debian/pull/349/commits/1944e1019e19fbecf28f3b756d69aa0e8ccabe5a) commit.

NOTE:
If rewrite the source URL in the same environment and run it again, remove the "./build/downloads/CVE_CHECK/DEBIAN/dst.json" file before running bitbake.

1. Test in Deby's docker environment.
   ```
   meta-debian$ cd docker/
   meta-debian/docker$ make start
   ```

2. Setup build environment within Deby's docker.
   ```
   source poky/meta-debian/tests/common.sh
   setup_builddir
   echo 'MACHINE = "qemuarm64"' >> ./conf/local.conf
   echo 'DISTRO = "deby"' >> ./conf/local.conf
   echo 'INHERIT += "cve-check debian-cve-check"' >> ./conf/local.conf
   ```

3. Run cve-check, and use scp to send CVE information file to HOST-PC.
   ```
   bitbake core-image-minimal
   ```
   Replace `<BEFORE|AFTER>` with the appropriate version.
   ```
   scp tmp/deploy/images/qemuarm64/core-image-minimal-qemuarm64.cve <USER>@<HOST-PC-IPADDR>:/tmp/<BEFORE|AFTER>.cve
   ```

4. Prepare the conversion script with HOST-PC.
   /tmp/conv.sh:
   ```
   #!/bin/bash
   
   cvelist=$1
   if ! [ -f $cvelist ]; then
       exit
   fi
   tmpfile="$1.tmp"
   output="$1.output"
   
   if [ -f $output ]; then
       rm "$output"
   fi
   
   pkg_name=""
   pkg_version=""
   cve_id=""
   cve_status=""
   while read line; do
       case "$line" in
       *:*)
           key=`echo "${line}" | cut -s -d: -f1`
           val=`echo "${line}" | cut -s -d: -f2`
           key=`echo -e $key`
           val=`echo -e $val`
           case "$key" in
           "PACKAGE NAME")
               pkg_name="$val";;
           "PACKAGE VERSION")
               pkg_version="$val";;
           "CVE")
               cve_id="$val";;
           "CVE STATUS")
               cve_status="$val";;
           esac;;
       *)
           if [ -n "$cve_id" ]; then
               echo "$cve_id, $cve_status, $pkg_name, $pkg_version" >> $tmpfile
           fi
           pkg_name=""
           pkg_version=""
           cve_id=""
           cve_status=""
       esac
   done < $cvelist
   
   cat $tmpfile | sort > $output
   rm $tmpfile
   echo "## CVE List convert success: $output"
   ```

5. Convert CVE information using conv.sh.
conv.sh outputs `.output` file in the same directory as the CVE information file specified as an argument.
   ```
   /tmp/conv.sh /tmp/BEFORE.cve
   /tmp/conv.sh /tmp/AFTER.cve
   ```

6. Compare the <BEFORE|AFTER>.cve.output files.
   ```
   diff -up /tmp/BEFORE.cve /tmp/AFTER.cve
   ```

## Test result
```
meta-debian/docker$ make start
docker-compose run work
WARNING: The IMAGE_ROOTFS_EXTRA_SPACE variable is not set. Defaulting to a blank string.
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
WARNING: The TEST_ENABLE_SECURITY_UPDATE variable is not set. Defaulting to a blank string.
deby@aefb553b0cb9:~$ source poky/meta-debian/tests/common.sh
deby@aefb553b0cb9:~$ setup_builddir
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

deby@aefb553b0cb9:~/build$ echo 'MACHINE = "qemuarm64"' >> ./conf/local.conf
deby@aefb553b0cb9:~/build$ echo 'DISTRO = "deby"' >> ./conf/local.conf
deby@aefb553b0cb9:~/build$ echo 'INHERIT += "cve-check debian-cve-check"' >> ./conf/local.conf
deby@aefb553b0cb9:~/build$ bitbake core-image-minimal
Parsing recipes: 100% |#################################################################################################| Time: 0:00:30
Parsing of 1041 .bb files complete (0 cached, 1041 parsed). 1822 targets, 66 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "change-json_url-to-freexian:435cd601f58b5c7b6a4d532a86fa5cca669ec4df"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 813 Found 0 Missed 813 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: flex-2.6.4-r0 do_cve_check: Found unpatched CVE (CVE-2015-1773 CVE-2019-6293), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/flex/2.6.4-r0/temp/cve.log
WARNING: bison-3.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2020-14150), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/bison/3.3.2-r0/temp/cve.log
WARNING: gawk-4.2.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-4156), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/gawk/4.2.1-r0/temp/cve.log
WARNING: gcc-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/gcc/8.3.0-r0/temp/cve.log
WARNING: unzip-6.0-r0 do_cve_check: Found unpatched CVE (CVE-2021-4217), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/unzip/6.0-r0/temp/cve.log
...<snip>...
WARNING: linux-base-gitAUTOINC+80b2464ae8-r0 do_cve_check: linux_kernel: Failed to compare gitAUTOINC+80b2464ae8 < 5.15.159 for CVE-2024-36938
WARNING: linux-base-gitAUTOINC+80b2464ae8-r0 do_cve_check: linux_kernel: Failed to compare gitAUTOINC+80b2464ae8 >= 4.6 for CVE-2024-36971
WARNING: linux-base-gitAUTOINC+80b2464ae8-r0 do_cve_check: linux_kernel: Failed to compare gitAUTOINC+80b2464ae8 < 6.9.4 for CVE-2024-36971
WARNING: libpng-native-1.6.36-r0 do_cve_check: Found unpatched CVE (CVE-2019-6129), for more information check /home/deby/build/tmp/work/x86_64-linux/libpng-native/1.6.36-r0/temp/cve.log
WARNING: qemu-system-native-3.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-20123 CVE-2018-20124 CVE-2018-20125 CVE-2018-20126 CVE-2018-20191 CVE-2018-20216 CVE-2019-12928 CVE-2019-12929 CVE-2019-20175 CVE-2019-8934 CVE-2020-25742 CVE-2020-25743 CVE-2020-35503 CVE-2021-3750 CVE-2022-36648 CVE-2022-3872 CVE-2022-4144 CVE-2023-1544 CVE-2023-3019), for more information check /home/deby/build/tmp/work/x86_64-linux/qemu-system-native/3.1-r0/temp/cve.log
Image CVE report stored in: /home/deby/build/tmp/deploy/images/qemuarm64/core-image-minimal-qemuarm64-20240618093116.rootfs.cve
NOTE: Tasks Summary: Attempted 3062 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 9912 WARNING messages shown.
```

Confirmed that the generated CVE information is the same.
```
$ diff -up BEFORE.cve.output AFTER.cve.output
$ echo $?
0
```
[AFTER.cve.output.txt](https://github.com/meta-debian/meta-debian/files/15499690/AFTER.cve.output.txt)
