### PR TITLE
gmp: Add ptest

### DIFF
--- a/recipes-debian/gmp/gmp/run-ptest
+++ b/recipes-debian/gmp/gmp/run-ptest
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+GMPLIB=@libdir@/gmp
+LOG="$GMPLIB/ptest/gmp_ptest_$(date +%Y%m%d-%H%M%S).log"
+
+make -C tests/ -k check-TESTS | tee -a "$LOG"
+for d in cxx misc mpf mpn mpq mpz rand; do
+    make -C tests/$d/ -k check-TESTS | tee -a "$LOG"
+done
+
+echo "=== Test Summary ===" | tee -a "$LOG"
+for key in TOTAL PASS SKIP XFAIL FAIL XPASS ERROR; do
+    count="$(grep "^# $key: " "$LOG" | awk '{total += $3} END {print total}')"
+    echo "$key: $count" | tee -a "$LOG"
+done

--- a/recipes-debian/gmp/gmp_debian.bb
+++ b/recipes-debian/gmp/gmp_debian.bb
@@ -9,6 +9,8 @@ inherit debian-package
 require recipes-debian/sources/gmp.inc
 DEBIAN_UNPACK_DIR = "${WORKDIR}/${BPN}-${REPACK_PV}"
 
+inherit ptest
+
 LICENSE = "GPLv2+ | LGPLv3+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d32239bcb673463ab874e80d47fae504 \
                    file://COPYING.LESSERv3;md5=6a6a8e020838b23406c81b19c1d46df6 \
@@ -19,6 +21,7 @@ SRC_URI += "file://amd64.patch \
             file://use-includedir.patch \
             file://0001-Append-the-user-provided-flags-to-the-auto-detected-.patch \
             file://0001-confiure.ac-Believe-the-cflags-from-environment.patch \
+            file://run-ptest \
            "
 FILESEXTRAPATHS =. "${COREBASE}/meta/recipes-support/gmp/gmp-6.1.2:"
 acpaths = ""
@@ -29,12 +32,53 @@ EXTRA_OECONF_mipsarchr6_append = " --disable-assembly"
 PACKAGES =+ "libgmpxx"
 FILES_libgmpxx = "${libdir}/libgmpxx${SOLIBS}"
 
+TESTDIR = "tests"
+
+do_compile_ptest() {
+    oe_runmake check TESTS=''
+}
+
 do_install_prepend_class-target() {
 	sed -i \
 	    -e "s|--sysroot=${STAGING_DIR_HOST}||g" \
 	    -e "s|${DEBUG_PREFIX_MAP}||g" \
 	    ${B}/gmp.h
 }
+
+do_install_ptest() {
+    install -m 755 ${S}/test-driver ${D}${PTEST_PATH}/
+    install -m 644 ${B}/*.la ${D}${PTEST_PATH}/
+
+    cp -r ${S}/${TESTDIR} ${D}${PTEST_PATH}/
+    cp -r ${B}/${TESTDIR}/* ${D}${PTEST_PATH}/${TESTDIR}/
+
+    sed -i \
+        -e 's|^VPATH =.*$|VPATH = .|g' \
+        -e 's|^Makefile:.*$|Makefile:|g' \
+        -e 's|^srcdir =.*|srcdir = .|g' \
+        -e 's|^top_srcdir =.*|top_srcdir = ..|g' \
+        -e 's|^abs_srcdir =.*|abs_srcdir = .|g' \
+        -e 's|^abs_top_srcdir =.*|abs_top_srcdir = ..|g' \
+        ${D}${PTEST_PATH}/${TESTDIR}/Makefile
+
+    install -m 755 ${B}/${TESTDIR}/.libs/* ${D}${PTEST_PATH}/${TESTDIR}/
+    for d in cxx misc mpf mpn mpq mpz rand; do
+        install -Dm 755 ${B}/${TESTDIR}/$d/.libs/* ${D}${PTEST_PATH}/${TESTDIR}/$d/
+        sed -i \
+            -e 's|^VPATH =.*$|VPATH = .|g' \
+            -e 's|^Makefile:.*$|Makefile:|g' \
+            -e 's|^srcdir =.*|srcdir = .|g' \
+            -e 's|^top_srcdir =.*|top_srcdir = ../..|g' \
+            -e 's|^abs_srcdir =.*|abs_srcdir = .|g' \
+            -e 's|^abs_top_srcdir =.*|abs_top_srcdir = ../..|g' \
+            ${D}${PTEST_PATH}/${TESTDIR}/$d/Makefile
+    done
+
+    # handle multilib
+    sed -i s:@libdir@:${libdir}:g ${D}${PTEST_PATH}/run-ptest
+}
+
+RDEPENDS_${PN}-ptest += "gawk make"
 
 SSTATE_SCAN_FILES += "gmp.h"
 


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of gmp.

This ptest executes `make check-TESTS` in `tests/` directory. There are some sub-directories under `tests/` directory, so it executes `make check-TESTS` there as well.

# Test
## How to test

1. Enable ptest and install gmp package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " gmp"
EOS
```

2. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of gmp

```
$ runqemu nographic slirp
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t 3600 gmp
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
gmp     /usr/lib/gmp/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t 3600 gmp
START: ptest-runner
2024-04-09T05:01
BEGIN: /usr/lib/gmp/ptest
make: Entering directory '/usr/lib/gmp/ptest/tests'
make[1]: Entering directory '/usr/lib/gmp/ptest/tests'
PASS: t-bswap
PASS: t-constants
PASS: t-count_zeros
...(snip)...
PASS: t-urbui
PASS: t-urmui
PASS: t-urndmm
============================================================================
Testsuite summary for GNU MP 6.1.2
============================================================================
# TOTAL: 7
# PASS:  7
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[1]: Leaving directory '/usr/lib/gmp/ptest/tests/rand'
make: Leaving directory '/usr/lib/gmp/ptest/tests/rand'
=== Test Summary ===
TOTAL: 190
PASS: 190
SKIP: 0
XFAIL: 0
FAIL: 0
XPASS: 0
ERROR: 0
DURATION: 718
END: /usr/lib/gmp/ptest
2024-04-09T05:13
STOP: ptest-runner
```

[ptest-gmp.log](https://github.com/ml-ichiro/meta-debian/files/14913868/ptest-gmp.log)

## Test summary

* TOTAL: 190
  * PASS: 190
  * FAIL: 0

I run this ptest 3 times and obtained the same results.