### PR TITLE
Add ptest lsb

### DIFF
--- a/recipes-debian/lsb/lsb/0001-test-Fix-range-of-exit-on-error-to-make-tests-keep-g.patch
+++ b/recipes-debian/lsb/lsb/0001-test-Fix-range-of-exit-on-error-to-make-tests-keep-g.patch
@@ -1,0 +1,30 @@
+From 5cd729ad89bb451ee2705290365103e5de7c0807 Mon Sep 17 00:00:00 2001
+From: Kazuho Sasaki <sasaki.kazuho@meta.co.jp>
+Date: Wed, 1 May 2024 15:22:08 +0900
+Subject: [PATCH] test: Fix range of exit-on-error to make tests keep going
+
+Signed-off-by: Kazuho Sasaki <sasaki.kazuho@meta.co.jp>
+---
+ test/lsb-test.sh | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/test/lsb-test.sh b/test/lsb-test.sh
+index 2db3457..177afcd 100644
+--- a/test/lsb-test.sh
++++ b/test/lsb-test.sh
+@@ -1,5 +1,6 @@
+-#!/bin/sh -e
++#!/bin/sh
+ 
++set -e
+ echo "Importing $1/init-functions"
+ . $1/init-functions
+ 
+@@ -8,6 +9,7 @@ log_success_msg "This should succeed"
+ log_failure_msg "This fails miserably"
+ 
+ echo "OK!"
++set +e
+ 
+ # Test pidofproc sanity checking.
+ 

--- a/recipes-debian/lsb/lsb/run-ptest
+++ b/recipes-debian/lsb/lsb/run-ptest
@@ -1,0 +1,2 @@
+#!/bin/sh
+./lsb-test.sh /lib/lsb

--- a/recipes-debian/lsb/lsb_debian.bb
+++ b/recipes-debian/lsb/lsb_debian.bb
@@ -95,5 +95,5 @@ RDEPENDS_${PN}-release += " \
     python3-core \
 "
 
-RPROVIDES_${PN} += "lsb-base"
+RPROVIDES_${PN} += "lsb-base initd-functions"
 PKG_${PN} = "lsb-base"

--- a/recipes-debian/lsb/lsb_debian.bb
+++ b/recipes-debian/lsb/lsb_debian.bb
@@ -13,7 +13,12 @@ inherit debian-package
 require recipes-debian/sources/lsb.inc
 DEBIAN_UNPACK_DIR = "${WORKDIR}/work"
 
-inherit python-dir
+inherit python-dir ptest
+
+SRC_URI += " \
+    file://run-ptest \
+    file://0001-test-Fix-range-of-exit-on-error-to-make-tests-keep-g.patch \
+"
 
 do_install(){
 	# Install files for lsb-base
@@ -64,6 +69,10 @@ do_install(){
 		ln -sf ld.so.1 ld-lsb-ppc32.so.2
 		ln -sf ld.so.1 ld-lsb-ppc32.so.3
 	fi
+}
+
+do_install_ptest() {
+    install -m 755 ${S}/test/lsb-test.sh ${D}${PTEST_PATH}
 }
 
 PACKAGES =+ "${PN}-release"


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of lsb package.
This ptest runs the test script `test/lsb-test.sh`.

Also fixes SDK build by adding `initd-functions` to `RPROVIDES`.
See Note for more details.

# Note

## ptest

The original test scripts sets `#!/bin/sh -e` as shebang, but it prevents tests keep going.
`0001-test-Fix-range-of-exit-on-error-to-make-tests-keep-g.patch` fixes this issue.

## SDK build

If lsb package is installed, SDK build fails as follows:
(This has nothing to do with ptest.)

```
WARNING: core-image-minimal-1.0-r0 do_populate_sdk: Unable to install packages. Command '/home/meta-sasaki/deby-bsp/build/tmp/work/qemuarm64-deby-linux/core-image-minimal/1.0-r0/recipe-sysroot-native/usr/bin/apt-get  install --force-yes --allow-unauthenticated base-passwd-dev initscripts-dev modutils-initscripts-dev lsb-dev libgcc-s-src netbase-dbg sysvinit-inittab-dbg sysvinit-dev run-postinsts-dev update-rc.d-dbg libz-dbg libz-src busybox-src base-passwd-dbg init-ifupdown-dev sysvinit-dbg base-files-dbg glibc-locale-dbg modutils-initscripts-dbg packagegroup-core-standalone-sdk-target-dev kmod-src glibc-src packagegroup-core-boot-dev sysvinit-inittab-dev util-linux-dbg eudev-dbg base-files-dev kmod-dev eudev-dev lsb-dbg packagegroup-core-standalone-sdk-target-dbg initscripts-dbg eudev-src busybox-dev opkg-utils-dbg update-rc.d-dev gcc-runtime-dbg init-ifupdown-dbg sysvinit-src kmod-dbg util-linux-dev netbase-dev packagegroup-core-boot-dbg util-linux-src libgcc-s-dbg libz-dev run-postinsts-dbg base-passwd-src busybox-dbg' returned 100:
Reading package lists...
Building dependency tree...
Reading state information...
You might want to run 'apt-get -f install' to correct these:
The following packages have unmet dependencies:
 eudev-dev : Depends: libudev1 but it is not going to be installed
             Recommends: libglib-2.0-dev but it is not going to be installed
             Recommends: libkmod-dev but it is not installable
             Recommends: libudev-dev but it is not installable
 initscripts : Depends: initd-functions
               Recommends: initscripts-functions but it is not going to be installed
 kmod-dev : Depends: kmod (= 26-r0) but it is not going to be installed
            Recommends: bash-completion-dev but it is not going to be installed
            Recommends: libkmod-dev but it is not installable
            Recommends: update-alternatives-opkg-dev but it is not installable
 sysvinit : Depends: initd-functions
 util-linux-dev : Depends: libfdisk1 but it is not going to be installed
                  Depends: libmount1 but it is not going to be installed
                  Depends: libsmartcols1 but it is not going to be installed
                  Depends: util-linux (= 2.33.1-r0) but it is not going to be installed
                  Recommends: bash-completion-dev but it is not going to be installed
                  Recommends: bash-dev but it is not going to be installed
                  Recommends: bc-dev but it is not going to be installed
                  Recommends: btrfs-tools-dev but it is not going to be installed
                  Recommends: coreutils-dev but it is not going to be installed
                  Recommends: e2fsprogs-dev but it is not going to be installed
                  Recommends: grep-dev but it is not going to be installed
                  Recommends: iproute2-dev but it is not going to be installed
                  Recommends: mdadm-dev but it is not going to be installed
                  Recommends: ncurses-dev but it is not going to be installed
                  Recommends: ncurses-libncursesw-dev but it is not installable
                  Recommends: ncurses-libtinfo-dev but it is not installable
                  Recommends: procps-dev but it is not going to be installed
                  Recommends: sed-dev but it is not going to be installed
                  Recommends: socat-dev but it is not going to be installed
                  Recommends: tar-dev but it is not going to be installed
                  Recommends: update-alternatives-opkg-dev but it is not installable
                  Recommends: util-linux-agetty-dev but it is not installable
                  Recommends: util-linux-blkid-dev but it is not installable
                  Recommends: util-linux-blockdev-dev but it is not installable
                  Recommends: util-linux-cal-dev but it is not installable
                  Recommends: util-linux-chrt-dev but it is not installable
                  Recommends: util-linux-dmesg-dev but it is not installable
                  Recommends: util-linux-eject-dev but it is not installable
                  Recommends: util-linux-fallocate-dev but it is not installable
                  Recommends: util-linux-fdisk-dev but it is not installable
                  Recommends: util-linux-flock-dev but it is not installable
                  Recommends: util-linux-fsck-dev but it is not installable
                  Recommends: util-linux-fsfreeze-dev but it is not installable
                  Recommends: util-linux-fstrim-dev but it is not installable
                  Recommends: util-linux-getopt-dev but it is not installable
                  Recommends: util-linux-hexdump-dev but it is not installable
                  Recommends: util-linux-hwclock-dev but it is not installable
                  Recommends: util-linux-ionice-dev but it is not installable
                  Recommends: util-linux-kill-dev but it is not installable
                  Recommends: util-linux-last-dev but it is not installable
                  Recommends: util-linux-libfdisk-dev but it is not installable
                  Recommends: util-linux-libsmartcols-dev but it is not installable
                  Recommends: util-linux-logger-dev but it is not installable
                  Recommends: util-linux-losetup-dev but it is not installable
                  Recommends: util-linux-lsblk-dev but it is not installable
                  Recommends: util-linux-mesg-dev but it is not installable
                  Recommends: util-linux-mkswap-dev but it is not installable
                  Recommends: util-linux-more-dev but it is not installable
                  Recommends: util-linux-mount-dev but it is not installable
                  Recommends: util-linux-mountpoint-dev but it is not installable
                  Recommends: util-linux-nologin-dev but it is not installable
                  Recommends: util-linux-nsenter-dev but it is not installable
                  Recommends: util-linux-pivot-root-dev but it is not installable
                  Recommends: util-linux-readprofile-dev but it is not installable
                  Recommends: util-linux-renice-dev but it is not installable
                  Recommends: util-linux-rev-dev but it is not installable
                  Recommends: util-linux-rfkill-dev but it is not installable
                  Recommends: util-linux-setsid-dev but it is not installable
                  Recommends: util-linux-sulogin-dev but it is not installable
                  Recommends: util-linux-swapoff-dev but it is not installable
                  Recommends: util-linux-swapon-dev but it is not installable
                  Recommends: util-linux-switch-root-dev but it is not installable
                  Recommends: util-linux-taskset-dev but it is not installable
                  Recommends: util-linux-umount-dev but it is not installable
                  Recommends: util-linux-unshare-dev but it is not installable
                  Recommends: util-linux-utmpdump-dev but it is not installable
                  Recommends: util-linux-wall-dev but it is not installable
                  Recommends: which-dev but it is not going to be installed
                  Recommends: xz-dev but it is not going to be installed
E: Unmet dependencies. Try 'apt-get -f install' with no packages (or specify a solution).
```

This is because both poky's initscripts and meta-debian's lsb provide `/etc/init.d/functions`, and they are conflicted.

`/etc/init.d/functions` is maintained by `initd-functions` provider, and [initscripts recipe already has `initd-functions` in `RPROVIDES`](https://git.yoctoproject.org/poky/tree/meta/recipes-core/initscripts/initscripts_1.0.bb?h=warrior#n55).
Therefore, this PR fixes lsb's recipe in the same way.

# Test
## How to test

1. Enable ptest and install lsb package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " lsb"
EOS
```

2. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of lsb

```
$ runqemu nographic slirp
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t 3600 lsb
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
lsb     /usr/lib/lsb/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t 3600 lsb
START: ptest-runner
2024-05-01T08:01
BEGIN: /usr/lib/lsb/ptest
Importing /lib/lsb/init-functions
Only a warning ... (warning).
This should succeed.
This fails miserably ... failed!
OK!
Testing pidofproc command line checks
 Simple check, no options:
 With -p option:
 With -p option, but in wrong place:
./lsb-test.sh: invalid arguments
OK!
DURATION: 1
END: /usr/lib/lsb/ptest
2024-05-01T08:01
STOP: ptest-runner
```

[ptest-lsb.log](https://github.com/ml-ichiro/meta-debian/files/15175472/ptest-lsb.log)

## Test summary

* TOTAL: 2
  * PASS: 2
  * FAIL: 0

I run this ptest 3 times and obtained the same results.