### PR TITLE
pixman: Add ptest

### DIFF
--- a/recipes-debian/xorg-lib/pixman/run-ptest
+++ b/recipes-debian/xorg-lib/pixman/run-ptest
@@ -1,0 +1,2 @@
+#!/bin/sh
+make -k check

--- a/recipes-debian/xorg-lib/pixman_debian.bb
+++ b/recipes-debian/xorg-lib/pixman_debian.bb
@@ -12,6 +12,8 @@ require recipes-debian/sources/pixman.inc
 DEBIAN_PATCH_TYPE = "quilt"
 FILESPATH_append = ":${COREBASE}/meta/recipes-graphics/xorg-lib/pixman"
 
+inherit ptest
+
 # see http://cairographics.org/releases/ - only even minor versions are stable
 UPSTREAM_CHECK_REGEX = "pixman-(?P<pver>\d+\.(\d*[02468])+(\.\d+)+)"
 
@@ -35,7 +37,49 @@ EXTRA_OECONF_class-nativesdk = "--disable-gtk"
 SRC_URI += "\
             file://0001-ARM-qemu-related-workarounds-in-cpu-features-detecti.patch \
 	    file://0001-test-utils-Check-for-FE_INVALID-definition-before-us.patch \
+            file://run-ptest \
 "
+
+do_compile_ptest() {
+    oe_runmake check TESTS=
+}
+
+do_install_ptest() {
+    cp -r ${S}/pixman ${D}${PTEST_PATH}
+    cp -r ${S}/test ${D}${PTEST_PATH}
+    cp -r ${S}/demos ${D}${PTEST_PATH}
+    cp -r ${B}/pixman/* ${D}${PTEST_PATH}/pixman/
+    cp -r ${B}/test/* ${D}${PTEST_PATH}/test/
+
+    # Overwrite wrapper scripts
+    cp ${B}/pixman/.libs/* ${D}${PTEST_PATH}/pixman/
+    cp ${B}/test/.libs/* ${D}${PTEST_PATH}/test/
+
+    install -m 755 ${S}/test-driver ${D}${PTEST_PATH}
+    install -m 644 ${B}/Makefile ${D}${PTEST_PATH}
+    install -m 644 ${B}/test/*.la ${D}${PTEST_PATH}/test/
+
+    sed -i \
+        -e 's|^VPATH =.*$|VPATH = .|g' \
+        -e 's|^Makefile:.*$|Makefile:|g' \
+        -e 's|^all-am:.*$|all-am:|g' \
+        -e 's|^srcdir =.*$|srcdir = .|g' \
+        -e 's|^top_srcdir =.*$|top_srcdir = .|g' \
+        ${D}${PTEST_PATH}/Makefile
+
+    for d in pixman test demos; do
+        install -m 644 ${B}/$d/Makefile ${D}${PTEST_PATH}/$d/
+        sed -i \
+            -e 's|^VPATH =.*$|VPATH = .|g' \
+            -e 's|^Makefile:.*$|Makefile:|g' \
+            -e 's|^all-am:.*$|all-am:|g' \
+            -e 's|^srcdir =.*$|srcdir = .|g' \
+            -e 's|^top_srcdir =.*$|top_srcdir = ..|g' \
+            ${D}${PTEST_PATH}/$d/Makefile
+    done
+}
+
+RDEPENDS_${PN}-ptest += "make gawk"
 
 REQUIRED_DISTRO_FEATURES = ""
 


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of pixman package.
This ptest runs `make check`.

# Test
## How to test

1. Enable ptest and install lsb package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " pixman"
EOS
```

2. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of pixman

```
$ runqemu nographic slirp
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t 3600 pixman
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
pixman  /usr/lib/pixman/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t 3600 pixman
START: ptest-runner
2024-05-08T08:47
BEGIN: /usr/lib/pixman/ptest
Making check in pixman
make[1]: Entering directory '/usr/lib/pixman/ptest/pixman'
make[1]: Nothing to be done for 'check'.
make[1]: Leaving directory '/usr/lib/pixman/ptest/pixman'
Making check in demos
make[1]: Entering directory '/usr/lib/pixman/ptest/demos'
make[1]: Nothing to be done for 'check'.
make[1]: Leaving directory '/usr/lib/pixman/ptest/demos'
Making check in test
make[1]: Entering directory '/usr/lib/pixman/ptest/test'
make  check-TESTS
make[2]: Entering directory '/usr/lib/pixman/ptest/test'
make[3]: Entering directory '/usr/lib/pixman/ptest/test'
PASS: oob-test
PASS: infinite-loop
PASS: trap-crasher
PASS: fence-image-self-test
PASS: region-translate-test
PASS: fetch-test
PASS: a1-trap-test
PASS: prng-test
PASS: radial-invalid
PASS: pdf-op-test
PASS: region-test
PASS: combiner-test
PASS: scaling-crash-test
PASS: alpha-loop
PASS: scaling-helpers-test
PASS: thread-test
PASS: rotate-test
PASS: alphamap
PASS: gradient-crash-test
PASS: pixel-test
PASS: matrix-test
PASS: filter-reduction-test
PASS: composite-traps-test
PASS: region-contains-test
PASS: glyph-test
PASS: solid-test
PASS: stress-test
PASS: cover-test
PASS: blitters-test
PASS: affine-test
PASS: scaling-test
PASS: composite
PASS: tolerance-test
============================================================================
Testsuite summary for pixman 0.36.0
============================================================================
# TOTAL: 33
# PASS:  33
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[3]: Leaving directory '/usr/lib/pixman/ptest/test'
make[2]: Leaving directory '/usr/lib/pixman/ptest/test'
make[1]: Leaving directory '/usr/lib/pixman/ptest/test'
make[1]: Entering directory '/usr/lib/pixman/ptest'
make[1]: Nothing to be done for 'check-am'.
make[1]: Leaving directory '/usr/lib/pixman/ptest'
DURATION: 3297
END: /usr/lib/pixman/ptest
2024-05-08T09:42
STOP: ptest-runner
```

[ptest-pixman.log](https://github.com/ml-ichiro/meta-debian/files/15257513/ptest-pixman.log)

## Test summary

* TOTAL: 33
  * PASS: 33
  * FAIL: 0

I run this ptest 3 times and obtained the same results.