### PR TITLE
Support nvd api 2.0 to warrior

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -1,0 +1,330 @@
+# base recipe: meta/classes/cve-check.bbclass
+# base branch: warrior
+# base commit: 29b5805c629a3d73e4280adc7d109c2aa2b0bdd8
+
+# This class is used to check recipes against public CVEs.
+#
+# In order to use this class just inherit the class in the
+# local.conf file and it will add the cve_check task for
+# every recipe. The task can be used per recipe, per image,
+# or using the special cases "world" and "universe". The
+# cve_check task will print a warning for every unpatched
+# CVE found and generate a file in the recipe WORKDIR/cve
+# directory. If an image is build it will generate a report
+# in DEPLOY_DIR_IMAGE for all the packages used.
+#
+# Example:
+#   bitbake -c cve_check openssl
+#   bitbake core-image-sato
+#   bitbake -k -c cve_check universe
+#
+# DISCLAIMER
+#
+# This class/tool is meant to be used as support and not
+# the only method to check against CVEs. Running this tool
+# doesn't guarantee your packages are free of CVEs.
+
+# The product name that the CVE database uses.  Defaults to BPN, but may need to
+# be overriden per recipe (for example tiff.bb sets CVE_PRODUCT=libtiff).
+CVE_PRODUCT ??= "${BPN}"
+CVE_VERSION ??= "${PV}"
+
+CVE_CHECK_DB_DIR ?= "${DL_DIR}/CVE_CHECK"
+CVE_CHECK_DB_FILE ?= "${CVE_CHECK_DB_DIR}/nvdcve_1.1.db"
+
+CVE_CHECK_LOG ?= "${T}/cve.log"
+CVE_CHECK_TMP_FILE ?= "${TMPDIR}/cve_check"
+
+CVE_CHECK_DIR ??= "${DEPLOY_DIR}/cve"
+CVE_CHECK_MANIFEST ?= "${DEPLOY_DIR_IMAGE}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.cve"
+CVE_CHECK_COPY_FILES ??= "1"
+CVE_CHECK_CREATE_MANIFEST ??= "1"
+
+# Whitelist for packages (PN)
+CVE_CHECK_PN_WHITELIST ?= ""
+
+# Whitelist for CVE. If a CVE is found, then it is considered patched.
+# The value is a string containing space separated CVE values:
+# 
+# CVE_CHECK_WHITELIST = 'CVE-2014-2524 CVE-2018-1234'
+# 
+CVE_CHECK_WHITELIST ?= ""
+
+python do_cve_check () {
+    """
+    Check recipe for patched and unpatched CVEs
+    """
+
+    if os.path.exists(d.getVar("CVE_CHECK_DB_FILE")):
+        patched_cves = get_patches_cves(d)
+        patched, unpatched = check_cves(d, patched_cves)
+        if patched or unpatched:
+            cve_data = get_cve_info(d, patched + unpatched)
+            cve_write_data(d, patched, unpatched, cve_data)
+    else:
+        bb.note("No CVE database found, skipping CVE check")
+
+}
+
+addtask cve_check before do_build
+do_cve_check[depends] = "cve-update-db-native:do_populate_cve_db"
+do_cve_check[nostamp] = "1"
+
+python cve_check_cleanup () {
+    """
+    Delete the file used to gather all the CVE information.
+    """
+    bb.utils.remove(e.data.getVar("CVE_CHECK_TMP_FILE"))
+}
+
+addhandler cve_check_cleanup
+cve_check_cleanup[eventmask] = "bb.cooker.CookerExit"
+
+python cve_check_write_rootfs_manifest () {
+    """
+    Create CVE manifest when building an image
+    """
+
+    import shutil
+
+    if d.getVar("CVE_CHECK_COPY_FILES") == "1":
+        deploy_file = os.path.join(d.getVar("CVE_CHECK_DIR"), d.getVar("PN"))
+        if os.path.exists(deploy_file):
+            bb.utils.remove(deploy_file)
+
+    if os.path.exists(d.getVar("CVE_CHECK_TMP_FILE")):
+        bb.note("Writing rootfs CVE manifest")
+        deploy_dir = d.getVar("DEPLOY_DIR_IMAGE")
+        link_name = d.getVar("IMAGE_LINK_NAME")
+        manifest_name = d.getVar("CVE_CHECK_MANIFEST")
+        cve_tmp_file = d.getVar("CVE_CHECK_TMP_FILE")
+
+        shutil.copyfile(cve_tmp_file, manifest_name)
+
+        if manifest_name and os.path.exists(manifest_name):
+            manifest_link = os.path.join(deploy_dir, "%s.cve" % link_name)
+            # If we already have another manifest, update symlinks
+            if os.path.exists(os.path.realpath(manifest_link)):
+                os.remove(manifest_link)
+            os.symlink(os.path.basename(manifest_name), manifest_link)
+            bb.plain("Image CVE report stored in: %s" % manifest_name)
+}
+
+ROOTFS_POSTPROCESS_COMMAND_prepend = "${@'cve_check_write_rootfs_manifest; ' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
+do_rootfs[recrdeptask] += "${@'do_cve_check' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
+
+def get_patches_cves(d):
+    """
+    Get patches that solve CVEs using the "CVE: " tag.
+    """
+
+    import re
+
+    pn = d.getVar("PN")
+    cve_match = re.compile("CVE:( CVE\-\d{4}\-\d+)+")
+
+    # Matches last CVE-1234-211432 in the file name, also if written
+    # with small letters. Not supporting multiple CVE id's in a single
+    # file name.
+    cve_file_name_match = re.compile(".*([Cc][Vv][Ee]\-\d{4}\-\d+)")
+
+    patched_cves = set()
+    bb.debug(2, "Looking for patches that solves CVEs for %s" % pn)
+    for url in src_patches(d):
+        patch_file = bb.fetch.decodeurl(url)[2]
+
+        # Check patch file name for CVE ID
+        fname_match = cve_file_name_match.search(patch_file)
+        if fname_match:
+            cve = fname_match.group(1).upper()
+            patched_cves.add(cve)
+            bb.debug(2, "Found CVE %s from patch file name %s" % (cve, patch_file))
+
+        with open(patch_file, "r", encoding="utf-8") as f:
+            try:
+                patch_text = f.read()
+            except UnicodeDecodeError:
+                bb.debug(1, "Failed to read patch %s using UTF-8 encoding"
+                        " trying with iso8859-1" %  patch_file)
+                f.close()
+                with open(patch_file, "r", encoding="iso8859-1") as f:
+                    patch_text = f.read()
+
+        # Search for one or more "CVE: " lines
+        text_match = False
+        for match in cve_match.finditer(patch_text):
+            # Get only the CVEs without the "CVE: " tag
+            cves = patch_text[match.start()+5:match.end()]
+            for cve in cves.split():
+                bb.debug(2, "Patch %s solves %s" % (patch_file, cve))
+                patched_cves.add(cve)
+                text_match = True
+
+        if not fname_match and not text_match:
+            bb.debug(2, "Patch %s doesn't solve CVEs" % patch_file)
+
+    return patched_cves
+
+def check_cves(d, patched_cves):
+    """
+    Connect to the NVD database and find unpatched cves.
+    """
+    from distutils.version import LooseVersion
+
+    cves_unpatched = []
+    # CVE_PRODUCT can contain more than one product (eg. curl/libcurl)
+    products = d.getVar("CVE_PRODUCT").split()
+    # If this has been unset then we're not scanning for CVEs here (for example, image recipes)
+    if not products:
+        return ([], [])
+    pv = d.getVar("CVE_VERSION").split("+git")[0]
+
+    # If the recipe has been whitlisted we return empty lists
+    if d.getVar("PN") in d.getVar("CVE_CHECK_PN_WHITELIST").split():
+        bb.note("Recipe has been whitelisted, skipping check")
+        return ([], [])
+
+    old_cve_whitelist =  d.getVar("CVE_CHECK_CVE_WHITELIST")
+    if old_cve_whitelist:
+        bb.warn("CVE_CHECK_CVE_WHITELIST is deprecated, please use CVE_CHECK_WHITELIST.")
+    cve_whitelist = d.getVar("CVE_CHECK_WHITELIST").split()
+
+    import sqlite3
+    db_file = d.expand("file:${CVE_CHECK_DB_FILE}?mode=ro")
+    conn = sqlite3.connect(db_file, uri=True)
+
+    # For each of the known product names (e.g. curl has CPEs using curl and libcurl)...
+    for product in products:
+        if ":" in product:
+            vendor, product = product.split(":", 1)
+        else:
+            vendor = "%"
+
+        # Find all relevant CVE IDs.
+        for cverow in conn.execute("SELECT DISTINCT ID FROM PRODUCTS WHERE PRODUCT IS ? AND VENDOR LIKE ?", (product, vendor)):
+            cve = cverow[0]
+
+            if cve in cve_whitelist:
+                bb.note("%s-%s has been whitelisted for %s" % (product, pv, cve))
+                # TODO: this should be in the report as 'whitelisted'
+                patched_cves.add(cve)
+                continue
+            elif cve in patched_cves:
+                bb.note("%s has been patched" % (cve))
+                continue
+
+            vulnerable = False
+            for row in conn.execute("SELECT * FROM PRODUCTS WHERE ID IS ? AND PRODUCT IS ? AND VENDOR LIKE ?", (cve, product, vendor)):
+                (_, _, _, version_start, operator_start, version_end, operator_end) = row
+                #bb.debug(2, "Evaluating row " + str(row))
+
+                if (operator_start == '=' and pv == version_start) or version_start == '-':
+                    vulnerable = True
+                else:
+                    if operator_start:
+                        try:
+                            vulnerable_start =  (operator_start == '>=' and LooseVersion(pv) >= LooseVersion(version_start))
+                            vulnerable_start |= (operator_start == '>' and LooseVersion(pv) > LooseVersion(version_start))
+                        except:
+                            bb.warn("%s: Failed to compare %s %s %s for %s" %
+                                    (product, pv, operator_start, version_start, cve))
+                            vulnerable_start = False
+                    else:
+                        vulnerable_start = False
+
+                    if operator_end:
+                        try:
+                            vulnerable_end  = (operator_end == '<=' and LooseVersion(pv) <= LooseVersion(version_end))
+                            vulnerable_end |= (operator_end == '<' and LooseVersion(pv) < LooseVersion(version_end))
+                        except:
+                            bb.warn("%s: Failed to compare %s %s %s for %s" %
+                                    (product, pv, operator_end, version_end, cve))
+                            vulnerable_end = False
+                    else:
+                        vulnerable_end = False
+
+                    if operator_start and operator_end:
+                        vulnerable = vulnerable_start and vulnerable_end
+                    else:
+                        vulnerable = vulnerable_start or vulnerable_end
+
+                if vulnerable:
+                    bb.note("%s-%s is vulnerable to %s" % (product, pv, cve))
+                    cves_unpatched.append(cve)
+                    break
+
+            if not vulnerable:
+                bb.note("%s-%s is not vulnerable to %s" % (product, pv, cve))
+                # TODO: not patched but not vulnerable
+                patched_cves.add(cve)
+
+    conn.close()
+
+    return (list(patched_cves), cves_unpatched)
+
+def get_cve_info(d, cves):
+    """
+    Get CVE information from the database.
+    """
+
+    import sqlite3
+
+    cve_data = {}
+    conn = sqlite3.connect(d.getVar("CVE_CHECK_DB_FILE"))
+
+    for cve in cves:
+        for row in conn.execute("SELECT * FROM NVD WHERE ID IS ?", (cve,)):
+            cve_data[row[0]] = {}
+            cve_data[row[0]]["summary"] = row[1]
+            cve_data[row[0]]["scorev2"] = row[2]
+            cve_data[row[0]]["scorev3"] = row[3]
+            cve_data[row[0]]["modified"] = row[4]
+            cve_data[row[0]]["vector"] = row[5]
+
+    conn.close()
+    return cve_data
+
+def cve_write_data(d, patched, unpatched, cve_data):
+    """
+    Write CVE information in WORKDIR; and to CVE_CHECK_DIR, and
+    CVE manifest if enabled.
+    """
+
+    cve_file = d.getVar("CVE_CHECK_LOG")
+    nvd_link = "https://web.nvd.nist.gov/view/vuln/detail?vulnId="
+    write_string = ""
+    unpatched_cves = []
+    bb.utils.mkdirhier(os.path.dirname(cve_file))
+
+    for cve in sorted(cve_data):
+        write_string += "PACKAGE NAME: %s\n" % d.getVar("PN")
+        write_string += "PACKAGE VERSION: %s\n" % d.getVar("PV")
+        write_string += "CVE: %s\n" % cve
+        if cve in patched:
+            write_string += "CVE STATUS: Patched\n"
+        else:
+            unpatched_cves.append(cve)
+            write_string += "CVE STATUS: Unpatched\n"
+        write_string += "CVE SUMMARY: %s\n" % cve_data[cve]["summary"]
+        write_string += "CVSS v2 BASE SCORE: %s\n" % cve_data[cve]["scorev2"]
+        write_string += "CVSS v3 BASE SCORE: %s\n" % cve_data[cve]["scorev3"]
+        write_string += "VECTOR: %s\n" % cve_data[cve]["vector"]
+        write_string += "MORE INFORMATION: %s%s\n\n" % (nvd_link, cve)
+
+    if unpatched_cves:
+        bb.warn("Found unpatched CVE (%s), for more information check %s" % (" ".join(unpatched_cves),cve_file))
+
+    with open(cve_file, "w") as f:
+        bb.note("Writing file %s with CVE information" % cve_file)
+        f.write(write_string)
+
+    if d.getVar("CVE_CHECK_COPY_FILES") == "1":
+        cve_dir = d.getVar("CVE_CHECK_DIR")
+        bb.utils.mkdirhier(cve_dir)
+        deploy_file = os.path.join(cve_dir, d.getVar("PN"))
+        with open(deploy_file, "w") as f:
+            f.write(write_string)
+
+    if d.getVar("CVE_CHECK_CREATE_MANIFEST") == "1":
+        with open(d.getVar("CVE_CHECK_TMP_FILE"), "a") as f:
+            f.write("%s" % write_string)

--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -78,7 +78,7 @@ python cve_check_cleanup () {
 }
 
 addhandler cve_check_cleanup
-cve_check_cleanup[eventmask] = "bb.cooker.CookerExit"
+cve_check_cleanup[eventmask] = "bb.event.BuildCompleted"
 
 python cve_check_write_rootfs_manifest () {
     """
@@ -112,6 +112,7 @@ python cve_check_write_rootfs_manifest () {
 
 ROOTFS_POSTPROCESS_COMMAND_prepend = "${@'cve_check_write_rootfs_manifest; ' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
 do_rootfs[recrdeptask] += "${@'do_cve_check' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
+do_populate_sdk[recrdeptask] += "${@'do_cve_check' if d.getVar('CVE_CHECK_CREATE_MANIFEST') == '1' else ''}"
 
 def get_patches_cves(d):
     """
@@ -201,7 +202,8 @@ def check_cves(d, patched_cves):
             vendor = "%"
 
         # Find all relevant CVE IDs.
-        for cverow in conn.execute("SELECT DISTINCT ID FROM PRODUCTS WHERE PRODUCT IS ? AND VENDOR LIKE ?", (product, vendor)):
+        cve_cursor = conn.execute("SELECT DISTINCT ID FROM PRODUCTS WHERE PRODUCT IS ? AND VENDOR LIKE ?", (product, vendor))
+        for cverow in cve_cursor:
             cve = cverow[0]
 
             if cve in cve_whitelist:
@@ -214,7 +216,8 @@ def check_cves(d, patched_cves):
                 continue
 
             vulnerable = False
-            for row in conn.execute("SELECT * FROM PRODUCTS WHERE ID IS ? AND PRODUCT IS ? AND VENDOR LIKE ?", (cve, product, vendor)):
+            product_cursor = conn.execute("SELECT * FROM PRODUCTS WHERE ID IS ? AND PRODUCT IS ? AND VENDOR LIKE ?", (cve, product, vendor))
+            for row in product_cursor:
                 (_, _, _, version_start, operator_start, version_end, operator_end) = row
                 #bb.debug(2, "Evaluating row " + str(row))
 
@@ -252,11 +255,13 @@ def check_cves(d, patched_cves):
                     bb.note("%s-%s is vulnerable to %s" % (product, pv, cve))
                     cves_unpatched.append(cve)
                     break
+            product_cursor.close()
 
             if not vulnerable:
                 bb.note("%s-%s is not vulnerable to %s" % (product, pv, cve))
                 # TODO: not patched but not vulnerable
                 patched_cves.add(cve)
+        cve_cursor.close()
 
     conn.close()
 
@@ -273,14 +278,15 @@ def get_cve_info(d, cves):
     conn = sqlite3.connect(d.getVar("CVE_CHECK_DB_FILE"))
 
     for cve in cves:
-        for row in conn.execute("SELECT * FROM NVD WHERE ID IS ?", (cve,)):
+        cursor = conn.execute("SELECT * FROM NVD WHERE ID IS ?", (cve,))
+        for row in cursor:
             cve_data[row[0]] = {}
             cve_data[row[0]]["summary"] = row[1]
             cve_data[row[0]]["scorev2"] = row[2]
             cve_data[row[0]]["scorev3"] = row[3]
             cve_data[row[0]]["modified"] = row[4]
             cve_data[row[0]]["vector"] = row[5]
-
+        cursor.close()
     conn.close()
     return cve_data
 
@@ -291,7 +297,7 @@ def cve_write_data(d, patched, unpatched, cve_data):
     """
 
     cve_file = d.getVar("CVE_CHECK_LOG")
-    nvd_link = "https://web.nvd.nist.gov/view/vuln/detail?vulnId="
+    nvd_link = "https://nvd.nist.gov/vuln/detail/"
     write_string = ""
     unpatched_cves = []
     bb.utils.mkdirhier(os.path.dirname(cve_file))

--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -30,7 +30,7 @@ CVE_PRODUCT ??= "${BPN}"
 CVE_VERSION ??= "${PV}"
 
 CVE_CHECK_DB_DIR ?= "${DL_DIR}/CVE_CHECK"
-CVE_CHECK_DB_FILE ?= "${CVE_CHECK_DB_DIR}/nvdcve_1.1.db"
+CVE_CHECK_DB_FILE ?= "${CVE_CHECK_DB_DIR}/nvdcve_2.db"
 
 CVE_CHECK_LOG ?= "${T}/cve.log"
 CVE_CHECK_TMP_FILE ?= "${TMPDIR}/cve_check"
@@ -67,7 +67,7 @@ python do_cve_check () {
 }
 
 addtask cve_check before do_build
-do_cve_check[depends] = "cve-update-db-native:do_populate_cve_db"
+do_cve_check[depends] = "cve-update-nvd2-native:do_populate_cve_db"
 do_cve_check[nostamp] = "1"
 
 python cve_check_cleanup () {

--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -334,6 +334,10 @@ def update_db(conn, elt):
                 [cveId, cveDesc, cvssv2, cvssv3, date, accessVector]).close()
 
     try:
+        # Remove any pre-existing CVE configuration. Even for partial database
+        # update, those will be repopulated. This ensures that old
+        # configuration is not kept for an updated CVE.
+        conn.execute("delete from PRODUCTS where ID = ?", [cveId]).close()
         for config in elt['cve']['configurations']:
             # This is suboptimal as it doesn't handle AND/OR and negate, but is better than nothing
             for node in config["nodes"]:

--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -1,0 +1,346 @@
+# base recipe: meta/recipes-core/meta/cve-update-nvd2-native.bb
+# base branch: dunfell
+# base commit: 959e7b1432994ade7a79b074d8de3070a69c494f
+
+SUMMARY = "Updates the NVD CVE database"
+LICENSE = "MIT"
+
+# Important note:
+# This product uses the NVD API but is not endorsed or certified by the NVD.
+
+INHIBIT_DEFAULT_DEPS = "1"
+
+inherit native
+
+deltask do_unpack
+deltask do_patch
+deltask do_configure
+deltask do_compile
+deltask do_install
+deltask do_populate_sysroot
+
+NVDCVE_URL ?= "https://services.nvd.nist.gov/rest/json/cves/2.0"
+
+# If you have a NVD API key (https://nvd.nist.gov/developers/request-an-api-key)
+# then setting this to get higher rate limits.
+NVDCVE_API_KEY ?= ""
+
+# CVE database update interval, in seconds. By default: once a day (24*60*60).
+# Use 0 to force the update
+# Use a negative value to skip the update
+CVE_DB_UPDATE_INTERVAL ?= "86400"
+
+# Timeout for blocking socket operations, such as the connection attempt.
+CVE_SOCKET_TIMEOUT ?= "60"
+
+CVE_DB_TEMP_FILE ?= "${CVE_CHECK_DB_DIR}/temp_nvdcve_2.db"
+
+CVE_CHECK_DB_FILE ?= "${CVE_CHECK_DB_DIR}/nvdcve_2.db"
+
+python () {
+    if not bb.data.inherits_class("cve-check", d):
+        raise bb.parse.SkipRecipe("Skip recipe when cve-check class is not loaded.")
+}
+
+python do_fetch() {
+    """
+    Update NVD database with API 2.0
+    """
+    import bb.utils
+    import bb.progress
+    import shutil
+
+    bb.utils.export_proxies(d)
+
+    db_file = d.getVar("CVE_CHECK_DB_FILE")
+    db_dir = os.path.dirname(db_file)
+    db_tmp_file = d.getVar("CVE_DB_TEMP_FILE")
+
+    cleanup_db_download(db_file, db_tmp_file)
+    # By default let's update the whole database (since time 0)
+    database_time = 0
+
+    # The NVD database changes once a day, so no need to update more frequently
+    # Allow the user to force-update
+    try:
+        import time
+        update_interval = int(d.getVar("CVE_DB_UPDATE_INTERVAL"))
+        if update_interval < 0:
+            bb.note("CVE database update skipped")
+            return
+        if time.time() - os.path.getmtime(db_file) < update_interval:
+            bb.note("CVE database recently updated, skipping")
+            return
+        database_time = os.path.getmtime(db_file)
+
+    except OSError:
+        pass
+
+    bb.utils.mkdirhier(db_dir)
+    if os.path.exists(db_file):
+        shutil.copy2(db_file, db_tmp_file)
+
+    if update_db_file(db_tmp_file, d, database_time) == True:
+        # Update downloaded correctly, can swap files
+        shutil.move(db_tmp_file, db_file)
+    else:
+        # Update failed, do not modify the database
+        bb.warn("CVE database update failed")
+        os.remove(db_tmp_file)
+}
+
+do_fetch[lockfiles] += "${CVE_CHECK_DB_FILE_LOCK}"
+do_fetch[file-checksums] = ""
+do_fetch[vardeps] = ""
+
+def cleanup_db_download(db_file, db_tmp_file):
+    """
+    Cleanup the download space from possible failed downloads
+    """
+
+    # Clean up the updates done on the main file
+    # Remove it only if a journal file exists - it means a complete re-download
+    if os.path.exists("{0}-journal".format(db_file)):
+        # If a journal is present the last update might have been interrupted. In that case,
+        # just wipe any leftovers and force the DB to be recreated.
+        os.remove("{0}-journal".format(db_file))
+
+        if os.path.exists(db_file):
+            os.remove(db_file)
+
+    # Clean-up the temporary file downloads, we can remove both journal
+    # and the temporary database
+    if os.path.exists("{0}-journal".format(db_tmp_file)):
+        # If a journal is present the last update might have been interrupted. In that case,
+        # just wipe any leftovers and force the DB to be recreated.
+        os.remove("{0}-journal".format(db_tmp_file))
+
+    if os.path.exists(db_tmp_file):
+        os.remove(db_tmp_file)
+
+def nvd_request_next(url, api_key, args):
+    """
+    Request next part of the NVD dabase
+    """
+
+    import urllib.request
+    import urllib.parse
+    import gzip
+    import http
+    import time
+
+    request = urllib.request.Request(url + "?" + urllib.parse.urlencode(args))
+    if api_key:
+        request.add_header("apiKey", api_key)
+    bb.note("Requesting %s" % request.full_url)
+
+    for attempt in range(5):
+        try:
+            r = urllib.request.urlopen(request)
+
+            if (r.headers['content-encoding'] == 'gzip'):
+                buf = r.read()
+                raw_data = gzip.decompress(buf).decode("utf-8")
+            else:
+                raw_data = r.read().decode("utf-8")
+
+            r.close()
+
+        except Exception as e:
+            bb.note("CVE database: received error (%s), retrying" % (e))
+            time.sleep(6)
+            pass
+        else:
+            return raw_data
+    else:
+        # We failed at all attempts
+        return None
+
+def update_db_file(db_tmp_file, d, database_time):
+    """
+    Update the given database file
+    """
+    import bb.utils, bb.progress
+    import datetime
+    import sqlite3
+    import json
+
+    # Connect to database
+    conn = sqlite3.connect(db_tmp_file)
+    initialize_db(conn)
+
+    req_args = {'startIndex' : 0}
+
+    # The maximum range for time is 120 days
+    # Force a complete update if our range is longer
+    if (database_time != 0):
+        database_date = datetime.datetime.fromtimestamp(database_time, tz=datetime.timezone.utc)
+        today_date = datetime.datetime.now(tz=datetime.timezone.utc)
+        delta = today_date - database_date
+        if delta.days < 120:
+            bb.note("CVE database: performing partial update")
+            req_args['lastModStartDate'] = database_date.isoformat()
+            req_args['lastModEndDate'] = today_date.isoformat()
+        else:
+            bb.note("CVE database: file too old, forcing a full update")
+
+    with bb.progress.ProgressHandler(d) as ph, open(os.path.join(d.getVar("TMPDIR"), 'cve_check'), 'a') as cve_f:
+
+        bb.note("Updating entries")
+        index = 0
+        url = d.getVar("NVDCVE_URL")
+        api_key = d.getVar("NVDCVE_API_KEY") or None
+
+        while True:
+            req_args['startIndex'] = index
+            raw_data = nvd_request_next(url, api_key, req_args)
+            if raw_data is None:
+                # We haven't managed to download data
+                return False
+
+            data = json.loads(raw_data)
+
+            index = data["startIndex"]
+            total = data["totalResults"]
+            per_page = data["resultsPerPage"]
+            bb.note("Got %d entries" % per_page)
+            for cve in data["vulnerabilities"]:
+               update_db(conn, cve)
+
+            index += per_page
+            ph.update((float(index) / (total+1)) * 100)
+            if index >= total:
+               break
+
+            # Recommended by NVD
+            time.sleep(6)
+
+        # Update success, set the date to cve_check file.
+        cve_f.write('CVE database update : %s\n\n' % datetime.date.today())
+
+    conn.commit()
+    conn.close()
+    return True
+
+def initialize_db(conn):
+    with conn:
+        c = conn.cursor()
+
+        c.execute("CREATE TABLE IF NOT EXISTS META (YEAR INTEGER UNIQUE, DATE TEXT)")
+
+        c.execute("CREATE TABLE IF NOT EXISTS NVD (ID TEXT UNIQUE, SUMMARY TEXT, \
+            SCOREV2 TEXT, SCOREV3 TEXT, MODIFIED INTEGER, VECTOR TEXT)")
+
+        c.execute("CREATE TABLE IF NOT EXISTS PRODUCTS (ID TEXT, \
+            VENDOR TEXT, PRODUCT TEXT, VERSION_START TEXT, OPERATOR_START TEXT, \
+            VERSION_END TEXT, OPERATOR_END TEXT)")
+        c.execute("CREATE INDEX IF NOT EXISTS PRODUCT_ID_IDX on PRODUCTS(ID);")
+
+        c.close()
+
+def parse_node_and_insert(conn, node, cveId):
+
+    def cpe_generator():
+        for cpe in node.get('cpeMatch', ()):
+            if not cpe['vulnerable']:
+                return
+            cpe23 = cpe.get('criteria')
+            if not cpe23:
+                return
+            cpe23 = cpe23.split(':')
+            if len(cpe23) < 6:
+                return
+            vendor = cpe23[3]
+            product = cpe23[4]
+            version = cpe23[5]
+
+            if cpe23[6] == '*' or cpe23[6] == '-':
+                version_suffix = ""
+            else:
+                version_suffix = "_" + cpe23[6]
+
+            if version != '*' and version != '-':
+                # Version is defined, this is a '=' match
+                yield [cveId, vendor, product, version + version_suffix, '=', '', '']
+            elif version == '-':
+                # no version information is available
+                yield [cveId, vendor, product, version, '', '', '']
+            else:
+                # Parse start version, end version and operators
+                op_start = ''
+                op_end = ''
+                v_start = ''
+                v_end = ''
+
+                if 'versionStartIncluding' in cpe:
+                    op_start = '>='
+                    v_start = cpe['versionStartIncluding']
+
+                if 'versionStartExcluding' in cpe:
+                    op_start = '>'
+                    v_start = cpe['versionStartExcluding']
+
+                if 'versionEndIncluding' in cpe:
+                    op_end = '<='
+                    v_end = cpe['versionEndIncluding']
+
+                if 'versionEndExcluding' in cpe:
+                    op_end = '<'
+                    v_end = cpe['versionEndExcluding']
+
+                if op_start or op_end or v_start or v_end:
+                    yield [cveId, vendor, product, v_start, op_start, v_end, op_end]
+                else:
+                    # This is no version information, expressed differently.
+                    # Save processing by representing as -.
+                    yield [cveId, vendor, product, '-', '', '', '']
+
+    conn.executemany("insert into PRODUCTS values (?, ?, ?, ?, ?, ?, ?)", cpe_generator()).close()
+
+def update_db(conn, elt):
+    """
+    Update a single entry in the on-disk database
+    """
+
+    accessVector = None
+    cveId = elt['cve']['id']
+    if elt['cve']['vulnStatus'] ==  "Rejected":
+        return
+    cveDesc = ""
+    for desc in elt['cve']['descriptions']:
+        if desc['lang'] == 'en':
+            cveDesc = desc['value']
+    date = elt['cve']['lastModified']
+    try:
+        accessVector = elt['cve']['metrics']['cvssMetricV2'][0]['cvssData']['accessVector']
+        cvssv2 = elt['cve']['metrics']['cvssMetricV2'][0]['cvssData']['baseScore']
+    except KeyError:
+        cvssv2 = 0.0
+    cvssv3 = None
+    try:
+        accessVector = accessVector or elt['cve']['metrics']['cvssMetricV30'][0]['cvssData']['attackVector']
+        cvssv3 = elt['cve']['metrics']['cvssMetricV30'][0]['cvssData']['baseScore']
+    except KeyError:
+        pass
+    try:
+        accessVector = accessVector or elt['cve']['metrics']['cvssMetricV31'][0]['cvssData']['attackVector']
+        cvssv3 = cvssv3 or elt['cve']['metrics']['cvssMetricV31'][0]['cvssData']['baseScore']
+    except KeyError:
+        pass
+    accessVector = accessVector or "UNKNOWN"
+    cvssv3 = cvssv3 or 0.0
+
+    conn.execute("insert or replace into NVD values (?, ?, ?, ?, ?, ?)",
+                [cveId, cveDesc, cvssv2, cvssv3, date, accessVector]).close()
+
+    try:
+        for config in elt['cve']['configurations']:
+            # This is suboptimal as it doesn't handle AND/OR and negate, but is better than nothing
+            for node in config["nodes"]:
+                parse_node_and_insert(conn, node, cveId)
+    except KeyError:
+        bb.note("CVE %s has no configurations" % cveId)
+
+do_fetch[nostamp] = "1"
+
+EXCLUDE_FROM_WORLD = "1"

--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -187,6 +187,11 @@ def update_db_file(db_tmp_file, d, database_time):
         url = d.getVar("NVDCVE_URL")
         api_key = d.getVar("NVDCVE_API_KEY") or None
 
+        # Recommended by NVD
+        wait_time = 6
+        if api_key:
+            wait_time = 2
+
         while True:
             req_args['startIndex'] = index
             raw_data = nvd_request_next(url, api_key, req_args)
@@ -208,7 +213,7 @@ def update_db_file(db_tmp_file, d, database_time):
                break
 
             # Recommended by NVD
-            time.sleep(6)
+            time.sleep(wait_time)
 
         # Update success, set the date to cve_check file.
         cve_f.write('CVE database update : %s\n\n' % datetime.date.today())

--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -305,6 +305,10 @@ def update_db(conn, elt):
     accessVector = None
     cveId = elt['cve']['id']
     if elt['cve']['vulnStatus'] ==  "Rejected":
+        c = conn.cursor()
+        c.execute("delete from PRODUCTS where ID = ?;", [cveId])
+        c.execute("delete from NVD where ID = ?;", [cveId])
+        c.close()
         return
     cveDesc = ""
     for desc in elt['cve']['descriptions']:

--- a/recipes-core/cve-update/cve-update-nvd2-native.bb
+++ b/recipes-core/cve-update/cve-update-nvd2-native.bb
@@ -42,7 +42,7 @@ python () {
         raise bb.parse.SkipRecipe("Skip recipe when cve-check class is not loaded.")
 }
 
-python do_fetch() {
+python do_populate_cve_db() {
     """
     Update NVD database with API 2.0
     """
@@ -88,10 +88,6 @@ python do_fetch() {
         bb.warn("CVE database update failed")
         os.remove(db_tmp_file)
 }
-
-do_fetch[lockfiles] += "${CVE_CHECK_DB_FILE_LOCK}"
-do_fetch[file-checksums] = ""
-do_fetch[vardeps] = ""
 
 def cleanup_db_download(db_file, db_tmp_file):
     """
@@ -184,7 +180,7 @@ def update_db_file(db_tmp_file, d, database_time):
         else:
             bb.note("CVE database: file too old, forcing a full update")
 
-    with bb.progress.ProgressHandler(d) as ph, open(os.path.join(d.getVar("TMPDIR"), 'cve_check'), 'a') as cve_f:
+    with open(os.path.join(d.getVar("TMPDIR"), 'cve_check'), 'a') as cve_f:
 
         bb.note("Updating entries")
         index = 0
@@ -208,7 +204,6 @@ def update_db_file(db_tmp_file, d, database_time):
                update_db(conn, cve)
 
             index += per_page
-            ph.update((float(index) / (total+1)) * 100)
             if index >= total:
                break
 
@@ -341,6 +336,8 @@ def update_db(conn, elt):
     except KeyError:
         bb.note("CVE %s has no configurations" % cveId)
 
-do_fetch[nostamp] = "1"
+
+addtask do_populate_cve_db before do_fetch
+do_populate_cve_db[nostamp] = "1"
 
 EXCLUDE_FROM_WORLD = "1"


### PR DESCRIPTION
# Notes to reviewers:
- Please merge [PR#349](https://github.com/meta-debian/meta-debian/pull/349) first
- This PR was tested using version of added this patch to [PR#349](https://github.com/meta-debian/meta-debian/pull/349).

# Purpose of pull request
After December 15, 2023, all legacy data feeds and the 1.0 APIs of CVE database provided by NVD are going to be retired, transition to the 2.0 APIs is necessary.

See: 
- https://nvd.nist.gov/vuln/data-feeds
- https://nvd.nist.gov/General/News/change-timeline

The meta-emlinux is using the CVE database fetcher (access to NVD by legacy data feeds) provided by Poky-warrior, but Poky-warrior has already been EOL and the 2.0 APIs are not expected to be supported.

Therefore, we will replace the current CVE database fetcher with new one supporting the 2.0 APIs.

# Test
## How to test
1. Build qemuarm64 image
2. Check cve-check works

### Build qemuarm64 image
Add the following to local.conf and build qemuarm64 image.
```
DISTRO = "deby"
MACHINE = "qemuarm64"
INHERIT += " cve-check debian-cve-check"
```
```
$ bitbake core-image-minimal
```

### Check cve-check works
Check items:
- Unpatched CVE report warnings is displayed during bitbake built
- The CVE database file is created
- The CVE logs is created for each package
- The CVE list for build image is created

## Test result
### Build image
Unpatched CVE report warnings was displayed.
```
build$ bitbake core-image-minimal
Parsing recipes: 100% |#################################################################################################| Time: 0:01:10
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "support-nvd-api-2.0-to-warrior:75284e21f801204cae5012ebfbe2737e86f2e3bb"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |##############################################################################################| Time: 0:00:04
Sstate summary: Wanted 843 Found 0 Missed 843 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: flex-2.6.4-r0 do_cve_check: Found unpatched CVE (CVE-2015-1773 CVE-2019-6293), for more information check /package-update/test1/after/build/tmp/work/aarch64-deby-linux/flex/2.6.4-r0/temp/cve.log
WARNING: bison-3.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2020-14150), for more information check /package-update/test1/after/build/tmp/work/aarch64-deby-linux/bison/3.3.2-r0/temp/cve.log
WARNING: patchelf-native-0.9-r0 do_cve_check: Found unpatched CVE (CVE-2022-44940), for more information check /package-update/test1/after/build/tmp/work/x86_64-linux/patchelf-native/0.9-r0/temp/cve.log
WARNING: gawk-4.2.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-4156), for more information check /package-update/test1/after/build/tmp/work/aarch64-deby-linux/gawk/4.2.1-r0/temp/cve.log
WARNING: gcc-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /package-update/test1/after/build/tmp/work/aarch64-deby-linux/gcc/8.3.0-r0/temp/cve.log
...snip...
WARNING: libgcc-initial-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /package-update/test1/after/build/tmp/work/aarch64-deby-linux/libgcc-initial/8.3.0-r0/temp/cve.log
WARNING: qemu-native-3.1-r0 do_cve_check: Found unpatched CVE (CVE-2007-0998 CVE-2018-20123 CVE-2018-20124 CVE-2018-20125 CVE-2018-20126 CVE-2018-20191 CVE-2018-20216 CVE-2019-12067 CVE-2019-12928 CVE-2019-12929 CVE-2019-20175 CVE-2019-8934 CVE-2020-25742 CVE-2020-25743 CVE-2020-35503 CVE-2021-20255 CVE-2021-3750 CVE-2022-36648 CVE-2022-3872 CVE-2022-4144 CVE-2023-1386 CVE-2023-1544 CVE-2023-3019 CVE-2024-6505), for more information check /package-update/test1/after/build/tmp/work/x86_64-linux/qemu-native/3.1-r0/temp/cve.log
WARNING: linux-base-gitAUTOINC+72fd755c49-r0 do_cve_check: Found unpatched CVE (CVE-1999-0524 CVE-1999-0656 CVE-2006-2932 CVE-2007-2764 CVE-2007-4998 CVE-2008-2544 CVE-2008-4609 CVE-2010-4563 CVE-2014-8171 CVE-2016-0774 CVE-2016-3695 CVE-2016-3699 CVE-2017-1000255 CVE-2017-1000377 CVE-2017-6264 CVE-2018-10840 CVE-2018-10876 CVE-2018-10882 CVE-2018-10902 CVE-2018-14625 CVE-2018-6559 CVE-2019-14899 CVE-2020-10742 CVE-2020-16119 CVE-2020-1749 CVE-2020-25672 CVE-2020-8834 CVE-2021-20265 CVE-2021-3669 CVE-2021-3714 CVE-2021-3759 CVE-2021-3864 CVE-2021-4218 CVE-2022-0286 CVE-2022-0400 CVE-2022-1247 CVE-2022-1462 CVE-2022-2308 CVE-2022-2327 CVE-2022-2663 CVE-2022-3435 CVE-2022-3523 CVE-2022-3534 CVE-2022-3566 CVE-2022-3567 CVE-2022-3619 CVE-2022-3621 CVE-2022-3624 CVE-2022-3629 CVE-2022-3630 CVE-2022-3633 CVE-2022-3636 CVE-2022-36402 CVE-2022-3646 CVE-2022-42895 CVE-2022-4382 CVE-2022-4543 CVE-2023-1073 CVE-2023-1074 CVE-2023-1075 CVE-2023-1076 CVE-2023-2898 CVE-2023-3397 CVE-2023-3640 CVE-2023-3772 CVE-2023-3773 CVE-2023-4010 CVE-2023-4155 CVE-2023-52904 CVE-2023-6176 CVE-2023-6238 CVE-2023-6240 CVE-2023-6270 CVE-2023-6535 CVE-2023-6606 CVE-2023-6610 CVE-2023-6679 CVE-2023-7042 CVE-2024-0193), for more information check /package-update/test1/after/build/tmp/work/qemuarm64-deby-linux/linux-base/gitAUTOINC+72fd755c49-r0/temp/cve.log
WARNING: libpng-native-1.6.36-r0 do_cve_check: Found unpatched CVE (CVE-2019-6129), for more information check /package-update/test1/after/build/tmp/work/x86_64-linux/libpng-native/1.6.36-r0/temp/cve.log
WARNING: qemu-system-native-3.1-r0 do_cve_check: Found unpatched CVE (CVE-2007-0998 CVE-2018-20123 CVE-2018-20124 CVE-2018-20125 CVE-2018-20126 CVE-2018-20191 CVE-2018-20216 CVE-2019-12067 CVE-2019-12928 CVE-2019-12929 CVE-2019-20175 CVE-2019-8934 CVE-2020-25742 CVE-2020-25743 CVE-2020-35503 CVE-2021-20255 CVE-2021-3750 CVE-2022-36648 CVE-2022-3872 CVE-2022-4144 CVE-2023-1386 CVE-2023-1544 CVE-2023-3019 CVE-2024-6505), for more information check /package-update/test1/after/build/tmp/work/x86_64-linux/qemu-system-native/3.1-r0/temp/cve.log
Image CVE report stored in: /package-update/test1/after/build/tmp/deploy/images/qemuarm64/core-image-minimal-qemuarm64-20240924093924.rootfs.cve
NOTE: Tasks Summary: Attempted 3181 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 15191 WARNING messages shown.
```

### CVE database file
The cve-update-nvd2-native step worked, The CVE database file was created.
```
build$ ls -F ./tmp/work/x86_64-linux/cve-update-nvd2-native/1.0-r0/temp/
log.do_cve_check@             log.task_order                run.do_populate_lic@                   run.sstate_report_unihash.28746
log.do_cve_check.31625        run.debian_cve_check.31625    run.do_populate_lic.28746              run.sstate_sign_package.28746
log.do_populate_cve_db@       run.do_cve_check@             run.populate_lic_qa_checksum.28746     run.sstate_task_postfunc.28746
log.do_populate_cve_db.30977  run.do_cve_check.31625        run.sstate_create_package.28746*       run.sstate_task_prefunc.28746
log.do_populate_lic@          run.do_populate_cve_db@       run.sstate_hardcode_path.28746         run.uninative_changeinterp.28746
log.do_populate_lic.28746     run.do_populate_cve_db.30977  run.sstate_hardcode_path_unpack.28746  run.update_dst.30977
build$ ls -F ./downloads/CVE_CHECK/
DEBIAN/  nvdcve_2.db
build$ file ./downloads/CVE_CHECK/nvdcve_2.db 
./downloads/CVE_CHECK/nvdcve_2.db: SQLite 3.x database, last written using SQLite version 3027002
```

### CVE logs for each package
A cve.log was created for each package.
```
build$ find . -name 'cve.log'
./tmp/work-shared/gcc-8.3.0-r0/temp/cve.log
./tmp/work/qemuarm64-deby-linux/base-files/10.3+deb10u13-r0/temp/cve.log
./tmp/work/qemuarm64-deby-linux/linux-base/gitAUTOINC+72fd755c49-r0/temp/cve.log
./tmp/work/x86_64-linux/openssl-native/1.1.1n-r0/temp/cve.log
./tmp/work/x86_64-linux/bison-native/3.3.2-r0/temp/cve.log
./tmp/work/x86_64-linux/tcl-native/8.6.9-r0/temp/cve.log
./tmp/work/x86_64-linux/alsa-lib-native/1.1.8-r0/temp/cve.log
./tmp/work/x86_64-linux/libtirpc-native/1.1.4-r0/temp/cve.log
./tmp/work/x86_64-linux/readline-native/7.0-r0/temp/cve.log
./tmp/work/x86_64-linux/ed-native/1.15-r0/temp/cve.log
./tmp/work/x86_64-linux/e2fsprogs-native/1.44.5-r0/temp/cve.log
./tmp/work/x86_64-linux/flex-native/2.6.4-r0/temp/cve.log
./tmp/work/x86_64-linux/cdrtools-native/3.01a31+really3.01-r0/temp/cve.log
./tmp/work/x86_64-linux/groff-native/1.22.4-r0/temp/cve.log
./tmp/work/x86_64-linux/elfutils-native/0.176-r0/temp/cve.log
./tmp/work/x86_64-linux/zlib-native/1.2.11-r0/temp/cve.log
./tmp/work/x86_64-linux/pixman-native/0.36.0-r0/temp/cve.log
./tmp/work/x86_64-linux/cross-localedef-native/2.28-r0/temp/cve.log
./tmp/work/x86_64-linux/sqlite3-native/3_3.27.2-r0/temp/cve.log
./tmp/work/x86_64-linux/nspr-native/4.20-r0/temp/cve.log
./tmp/work/x86_64-linux/libarchive-native/3.3.3-r0/temp/cve.log
./tmp/work/x86_64-linux/qemu-system-native/3.1-r0/temp/cve.log
./tmp/work/x86_64-linux/libxml2-native/2.9.4-r0/temp/cve.log
./tmp/work/x86_64-linux/perl-native/5.28.1-r1/temp/cve.log
./tmp/work/x86_64-linux/glib-2.0-native/2.58.3-r0/temp/cve.log
./tmp/work/x86_64-linux/gcc-cross-aarch64/8.3.0-r0/temp/cve.log
./tmp/work/x86_64-linux/ncurses-native/6.1+20181013-r0/temp/cve.log
./tmp/work/x86_64-linux/syslinux-native/6.04~git20190206.bf6db5b4-r0/temp/cve.log
./tmp/work/x86_64-linux/m4-native/1.4.18-r0/temp/cve.log
./tmp/work/x86_64-linux/gettext-native/0.19.8.1-r0/temp/cve.log
./tmp/work/x86_64-linux/gmp-native/6.1.2-r0/temp/cve.log
./tmp/work/x86_64-linux/patchelf-native/0.9-r0/temp/cve.log
./tmp/work/x86_64-linux/libpcre-native/8.39-r0/temp/cve.log
./tmp/work/x86_64-linux/xz-native/5.2.4-r0/temp/cve.log
./tmp/work/x86_64-linux/util-linux-native/2.33.1-r0/temp/cve.log
./tmp/work/x86_64-linux/re2c-native/1.1.1-r0/temp/cve.log
./tmp/work/x86_64-linux/file-native/5.35-r0/temp/cve.log
./tmp/work/x86_64-linux/shadow-native/4.5-r0/temp/cve.log
./tmp/work/x86_64-linux/libffi-native/3.2.1-r0/temp/cve.log
./tmp/work/x86_64-linux/ipxe-native/1.0.0+git-20190125.36a4c85-r0/temp/cve.log
./tmp/work/x86_64-linux/binutils-cross-aarch64/2.31.1-r0/temp/cve.log
./tmp/work/x86_64-linux/pigz-native/2.4-r0/temp/cve.log
./tmp/work/x86_64-linux/expect-native/5.45.4-r0/temp/cve.log
./tmp/work/x86_64-linux/libtool-native/2.4.6-r0/temp/cve.log
./tmp/work/x86_64-linux/curl-native/7.64.0-r1/temp/cve.log
./tmp/work/x86_64-linux/dpkg-native/1.19.8-r0/temp/cve.log
./tmp/work/x86_64-linux/libpng-native/1.6.36-r0/temp/cve.log
./tmp/work/x86_64-linux/apt-native/1.2.24-r0/temp/cve.log
./tmp/work/x86_64-linux/nss-native/3.42.1-r0/temp/cve.log
./tmp/work/x86_64-linux/qemu-native/3.1-r0/temp/cve.log
./tmp/work/x86_64-linux/libxslt-native/1.1.32-r0/temp/cve.log
./tmp/work/x86_64-linux/ninja-native/1.8.2-r0/temp/cve.log
./tmp/work/x86_64-linux/dbus-native/1.12.28-r0/temp/cve.log
./tmp/work/x86_64-linux/rpm-native/4.14.2.1-r0/temp/cve.log
./tmp/work/x86_64-linux/bzip2-native/1.0.6-r0/temp/cve.log
./tmp/work/x86_64-linux/binutils-native/2.31.1-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/readline/7.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/tar/1.30-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libxcb/1.13.1-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/grep/3.3-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/procps/3.3.15-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/initscripts/1.0-r155/temp/cve.log
./tmp/work/aarch64-deby-linux/ncurses/6.1+20181013-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/m4/1.4.18-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/gcc/8.3.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/coreutils/8.30-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/perl/5.28.1-r1/temp/cve.log
./tmp/work/aarch64-deby-linux/libcap/2.25-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/gawk/4.2.1-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/iptables/1.8.2-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/glib-2.0/2.58.3-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/zip/3.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/iproute2/4.20.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/expect/5.45.4-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/elfutils/0.176-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/openssl/1.1.1n-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libpcre/8.39-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/dbus/1.12.28-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/acl/2.2.53-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libxdmcp/1.1.2-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/bzip2/1.0.6-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libxml2/2.9.4-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/e2fsprogs/1.44.5-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/mdadm/4.1-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/sqlite3/3_3.27.2-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libffi/3.2.1-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/tcl/8.6.9-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/socat/1.7.3.2-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/flex/2.6.4-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libtool-cross/2.4.6-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/findutils/4.6.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/shadow/4.5-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libgcc-initial/8.3.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/busybox/1.30.1-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/gcc-runtime/8.3.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/zlib/1.2.11-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/binutils/2.31.1-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libice/1.0.9-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/util-linux/2.33.1-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libx11/1.6.7-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/bison/3.3.2-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/glibc/2.28-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libgcc/8.3.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/unzip/6.0-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/xz/5.2.4-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/gmp/6.1.2-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libtool/2.4.6-r0/temp/cve.log
./tmp/work/aarch64-deby-linux/libtirpc/1.1.4-r0/temp/cve.log
build$ ls -F ./tmp/deploy/cve/
acl                     curl-native       gcc                libarchive-native  libxcb          patchelf-native     sqlite3-native
alsa-lib-native         dbus              gcc-cross-aarch64  libcap             libxdmcp        perl                syslinux-native
apt-native              dbus-native       gcc-runtime        libffi             libxml2         perl-native         tar
base-files              dpkg-native       gcc-source-8.3.0   libffi-native      libxml2-native  pigz-native         tcl
bash                    e2fsprogs         gettext-native     libgcc             libxslt-native  pixman-native       tcl-native
binutils                e2fsprogs-native  glib-2.0           libgcc-initial     linux-base      procps              unzip
binutils-cross-aarch64  ed-native         glib-2.0-native    libice             m4              qemu-native         util-linux
binutils-native         elfutils          glibc              libpcre            m4-native       qemu-system-native  util-linux-native
bison                   elfutils-native   gmp                libpcre-native     mdadm           re2c-native         xz
bison-native            expect            gmp-native         libpng-native      ncurses         readline            xz-native
busybox                 expect-native     grep               libtirpc           ncurses-native  readline-native     zip
bzip2                   file-native       groff-native       libtirpc-native    ninja-native    rpm-native          zlib
bzip2-native            findutils         initscripts        libtool            nspr-native     shadow              zlib-native
cdrtools-native         flex              iproute2           libtool-cross      nss-native      shadow-native
coreutils               flex-native       iptables           libtool-native     openssl         socat
cross-localedef-native  gawk              ipxe-native        libx11             openssl-native  sqlite3
```

### CVE list for build image
A CVE list (core-image-minimal-qemuarm64.cve) for target machine image was created.
```
build$ ls -F ./tmp/deploy/images/qemuarm64/
Image@                                                       core-image-minimal-qemuarm64.cve@
Image--git0+72fd755c49-r0-qemuarm64-20240924093924.bin       core-image-minimal-qemuarm64.ext4@
Image-qemuarm64.bin@                                         core-image-minimal-qemuarm64.manifest@
core-image-minimal-qemuarm64-20240924093924.qemuboot.conf    core-image-minimal-qemuarm64.qemuboot.conf@
core-image-minimal-qemuarm64-20240924093924.rootfs.cve       core-image-minimal-qemuarm64.tar.bz2@
core-image-minimal-qemuarm64-20240924093924.rootfs.ext4      core-image-minimal-qemuarm64.testdata.json@
core-image-minimal-qemuarm64-20240924093924.rootfs.manifest  modules--git0+72fd755c49-r0-qemuarm64-20240924093924.tgz
core-image-minimal-qemuarm64-20240924093924.rootfs.tar.bz2   modules-qemuarm64.tgz@
core-image-minimal-qemuarm64-20240924093924.testdata.json
```
