### PR TITLE
Docker: Update Compose syntax and optimize Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,8 +45,7 @@ RUN bash -c 'if test -n "$http_proxy"; then git config --global http.proxy "$htt
 RUN bash -c 'if test -n "$https_proxy"; then git config --global https.proxy "$https_proxy"; fi'
 RUN bash -c 'if test -n "$no_proxy"; then git config --global core.noproxy "$no_proxy"; fi'
 
-RUN git clone $POKY_GIT_URL $HOME/poky
-RUN cd $HOME/poky && git checkout $POKY_REV
+RUN git clone --depth 1 -b $POKY_REV $POKY_GIT_URL $HOME/poky
 RUN mkdir -p $HOME/poky/meta-debian
 RUN mkdir -p $HOME/$BUILDDIR
 RUN ln -sf $HOME/downloads $HOME/$BUILDDIR/downloads

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,28 +6,28 @@ endif
 export UID
 
 start:
-	docker-compose run work
+	docker compose run work
 
 refresh:
 	# Rebuild docker image
-	docker-compose build --no-cache work
+	docker compose build --no-cache work
 
 test: build_test qemu_ptest
 
 build_test:
-	docker-compose run --rm build_test
+	docker compose run --rm build_test
 
 qemu_ptest:
-	docker-compose run --rm qemu_ptest
+	docker compose run --rm qemu_ptest
 
 clean:
 	rm -rf ../tests/logs
 	rm -rf ../tests/html
 
 cleanall:
-	docker-compose rm -svf work
-	docker-compose rm -svf build_test
-	docker-compose rm -svf qemu_ptest
+	docker compose rm -svf work
+	docker compose rm -svf build_test
+	docker compose rm -svf qemu_ptest
 	docker volume rm -f docker_downloads
 	docker rmi -f deby-image
 


### PR DESCRIPTION
This pull request enhances the Docker environment in two ways:

First, it updates the Docker Compose syntax to V2, as Compose V1 stopped receiving updates in July 2023 (https://docs.docker.com/compose/migrate/). This change also resolves an error encountered when running `make -C docker/` on systems with a recent version of Docker Compose. The assumption is that anyone using the Docker environment, like myself, will be using a fairly recent version of Docker Compose that supports the V2 syntax.

Second, this pull request reduces the build time and size of the Docker image by shadow cloning a specific branch instead of cloning the full Poky repository and doing a checkout. A full Poky repository isn't necessary within the container and cloning just the last commit of the $POKY_REV branch is sufficient to build the system.