### PR TITLE
openssh: Add CVE-2023-51767 to whitelist

### DIFF
--- a/recipes-debian/openssh/openssh_debian.bb
+++ b/recipes-debian/openssh/openssh_debian.bb
@@ -163,3 +163,8 @@ ALTERNATIVE_${PN}-scp = "scp"
 ALTERNATIVE_${PN}-ssh = "ssh"
 
 BBCLASSEXTEND += "nativesdk"
+
+# Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and
+# does not intent to address it in OpenSSH
+# https://security-tracker.debian.org/tracker/CVE-2023-51767
+CVE_CHECK_WHITELIST += "CVE-2023-51767"


### PR DESCRIPTION
# Purpose of pull request
With the merge of #367, CVE-2023-51767 is now correctly detected.

Upstream does not consider CVE-2023-51767 a bug underlying in OpenSSH and does not intent to address it in OpenSSH.
So, add it to CVE_CHECK_WHITELIST.

https://nvd.nist.gov/vuln/detail/CVE-2023-51767
https://security-tracker.debian.org/tracker/CVE-2023-51767

From Poky rev: a095c9e6a349ecf5e73e74d05cb6a815877155bf

# Test
## How to test
Add following line into conf/local.conf.
```
INHERIT += "cve-check"
```
And then run following command.
```
$ bitbake openssh -c cve_check
```

## Test result
After this commit, CVE-2023-51767 status is Patched:
```
build$ grep -n -C 3 CVE-2023-51767 ./tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/temp/cve.log
1120-
1121-PACKAGE NAME: openssh
1122-PACKAGE VERSION: 7.9p1
1123:CVE: CVE-2023-51767
1124-CVE STATUS: Patched
1125-CVE SUMMARY: OpenSSH through 9.6, when common types of DRAM are used, might allow row hammer attacks (for authentication bypass) because the integer value of authenticated in mm_answer_authpassword does not resist flips of a single bit. NOTE: this is applicable to a certain threat model of attacker-victim co-location in which the attacker has user privileges.
1126-CVSS v2 BASE SCORE: 0.0
1127-CVSS v3 BASE SCORE: 7.0
1128-VECTOR: LOCAL
1129:MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2023-51767
1130-
1131-PACKAGE NAME: openssh
1132-PACKAGE VERSION: 7.9p1
```

Before this commit, CVE-2023-51767 status is Unpatched:
```
build$ grep -n -C 3 CVE-2023-51767 ./tmp/work/aarch64-deby-linux/openssh/7.9p1-r0/temp/cve.log
1120-
1121-PACKAGE NAME: openssh
1122-PACKAGE VERSION: 7.9p1
1123:CVE: CVE-2023-51767
1124-CVE STATUS: Unpatched
1125-CVE SUMMARY: OpenSSH through 9.6, when common types of DRAM are used, might allow row hammer attacks (for authentication bypass) because the integer value of authenticated in mm_answer_authpassword does not resist flips of a single bit. NOTE: this is applicable to a certain threat model of attacker-victim co-location in which the attacker has user privileges.
1126-CVSS v2 BASE SCORE: 0.0
1127-CVSS v3 BASE SCORE: 7.0
1128-VECTOR: LOCAL
1129:MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2023-51767
1130-
1131-PACKAGE NAME: openssh
1132-PACKAGE VERSION: 7.9p1
```