### PR TITLE
Improve DST database receiving

### DIFF
--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -70,7 +70,7 @@ python update_dst () {
             return
         except Exception as e:
             bb.debug(2, "DST database: received error (%s), retrying" % (e))
-            time.sleep(attempt * 3)
+            time.sleep(10 + (attempt * 10))
             continue
     else:
         bb.error("DST database received error")

--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -9,6 +9,7 @@
 
 DEBIAN_CVE_CHECK_DB_DIR ?= "${CVE_CHECK_DB_DIR}/DEBIAN"
 DEBIAN_CODENAME ?= "${DISTRO_CODENAME}"
+DEBIAN_SECRUTY_TRACKER_JSON_URL ??= "https://deb.freexian.com/extended-lts/tracker/data/json"
 
 python debian_cve_check () {
     """
@@ -50,7 +51,7 @@ python update_dst () {
     import time
     from datetime import datetime, date
 
-    json_url = "https://deb.freexian.com/extended-lts/tracker/data/json"
+    json_urls = d.getVar("DEBIAN_SECRUTY_TRACKER_JSON_URL", "").split(" ")
     dist_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True),"dst.json")
     dist_dir = os.path.dirname(dist_path)
 
@@ -62,16 +63,21 @@ python update_dst () {
         if timestamp.date() == date.today():
             return
 
-    for attempt in range(5):
-        try:
-            with urllib.request.urlopen(json_url) as response, open(dist_path, 'wb') as f:
-                shutil.copyfileobj(response, f)
-            bb.debug(2, "DST database updated")
-            return
-        except Exception as e:
-            bb.debug(2, "DST database: received error (%s), retrying" % (e))
-            time.sleep(10 + (attempt * 10))
-            continue
+    for json_url in json_urls:
+        bb.note("Download json file from %s" % json_url)
+        for attempt in range(5):
+            try:
+                with urllib.request.urlopen(json_url) as response, open(dist_path, 'wb') as f:
+                    shutil.copyfileobj(response, f)
+                bb.debug(2, "DST database updated")
+                return
+            except ValueError as e:
+                bb.warn("Invalid URL (%s)" % (e))
+                break
+            except Exception as e:
+                bb.debug(2, "DST database: received error (%s), retrying" % (e))
+                time.sleep(10 + (attempt * 10))
+                continue
     else:
         bb.error("DST database received error")
         return

--- a/doc/7.cve-check.md
+++ b/doc/7.cve-check.md
@@ -1,0 +1,24 @@
+# CVE Check feature
+
+The CVE check feature is based on Poky's CVE check functionality and uses NVD vulnerability information. However, the fixed versions listed in NVD vulnerability information may not match Debian package versions. As a result, relying solely on NVD vulnerability information could lead to Debian packages that have already been patched being mistakenly identified as unpatched. To address this issue, the CVE check feature in meta-debian utilizes Debian vulnerability information to eliminate false positives.
+
+# Variable
+
+- DEBIAN\_SECRUTY\_TRACKER\_JSON\_URL
+
+Debian 10 reached the end of LTS support in June 2024 and has been maintained as ELTS by Freexian since July 2024. Therefore, vulnerability information for Debian packages is sourced from the data provided by Freexian. However, retrieving vulnerability information from this server may sometimes fail, preventing the CVE check from being performed.
+
+To address this issue, users can now configure a mirror server to be used when downloading vulnerability information from Freexian's server fails. The ```DEBIAN_SECURITY_TRACKER_JSON_URL``` variable is set by default to Freexian's server URL, but users can modify its value or add additional URLs as needed. This setting can be in conf/local.conf or other file.
+
+Append URL:
+
+```
+DEBIAN_SECRUTY_TRACKER_JSON_URL_append = " http://localhost:8000/dst.json"
+```
+
+Replace URL:
+
+```
+DEBIAN_SECRUTY_TRACKER_JSON_URL = "http://localhost:8000/dst.json"
+```
+


### PR DESCRIPTION
# Purpose of pull request

Receiving DST database sometimes fails because of server response errors such as HTTP 503 or 504 status.
This PR impoves the workaround and allow users to add/change its URL to own mirror servers which provides the DST database.

## Workaround: change retry interval

Receiving DST database fails because server [1] returns 504 or 503.
As a workaround, extend retry interval.

[1] https://deb.freexian.com/extended-lts/tracker/data/json

## Own mirror: fallback URL

this commit allow user can change its URL or append fallback URL to their mirror server.

* add fallback mirror
  ```
  DEBIAN_SECRUTY_TRACKER_JSON_URL_append = " http://localhost:8000/dst.json"
  ```
* change mirror
  ```
  DEBIAN_SECRUTY_TRACKER_JSON_URL = "http://localhost:8000/dst.json"
  ```

# How to test

local.conf setting
```
DISTRO = "deby"
MACHINE = "qemuarm64"
INHERIT += " cve-check debian-cve-check"
```

## 1. Workaround: change retry interval

Run cve-check without dst.json file.
```
$ rm -f downloads/CVE_CHECK/DEBIAN/dst.json 
$ bitbake bash -c cve_check
```

Check log.do_populate_cve_db if a timeout error has occurred or not.
```
$ cat tmp/work/x86_64-linux/cve-update-nvd2-native/1.0-r0/temp/log.do_populate_cve_db
```

## 2. Own mirror: fallback URL

As test preparations, copy the dst.json file and run the http local server.
```
$ cp downloads/CVE_CHECK/DEBIAN/dst.json local/dst.json
$ busybox httpd -p 8000 -h local
```

## 2-1. Own mirror: append fallback URL

add the following line into local.conf.
```
DEBIAN_SECRUTY_TRACKER_JSON_URL_append = " http://localhost:8000/dst.json"
```
To test this case, I changed retry limit in the update_dst().
```
for attempt in range(5)
```
to
```
for attempt in range(1)
```

Run cve-check following command.
```
$ rm -fr downloads/CVE_CHECK/DEBIAN/dst.json
$ bitbake busybox -c cve_check
```

Check log.do_populate_cve_db if a fallback access has run or not.
```
$ cat tmp/work/x86_64-linux/cve-update-nvd2-native/1.0-r0/temp/log.do_populate_cve_db
```

## 2-2. Own mirror: change URL

add the following line into local.conf.
```
DEBIAN_SECRUTY_TRACKER_JSON_URL = " http://localhost:8000/dst.json"
```

Run cve-check following command.
```
$ rm -fr downloads/CVE_CHECK/DEBIAN/dst.json
$ bitbake busybox -c cve_check
```

Check log.do_populate_cve_db if a fallback access has run or not.
```
$ cat tmp/work/x86_64-linux/cve-update-nvd2-native/1.0-r0/temp/log.do_populate_cve_db
```

# Test results

## Before this PR

```
deby@87f54d60e631:~/build$ rm -f downloads/CVE_CHECK/DEBIAN/dst.json
deby@87f54d60e631:~/build$ bitbake bash -c cve_check
Parsing recipes: 100% |####################################################################| Time: 0:00:11
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:0fc67438e2f7b7868577520f6ce24dc7493e6063"

NOTE: Fetching uninative binary shim from http://downloads.yoctoproject.org/releases/uninative/2.9/x86_64-nativesdk-libc.tar.xz;sha256sum=d07916b95c419c81541a19c8ef0ed8cbd78ae18437ff28a4c8a60ef40518e423
Initialising tasks: 100% |#################################################################| Time: 0:00:00
```

Checked log.do_populate_cve_db:
```
DEBUG: Executing python function do_populate_cve_db
DEBUG: Python function do_populate_cve_db finished
DEBUG: Executing python function update_dst
DEBUG: DST database: received error (HTTP Error 504: Gateway Time-out), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
ERROR: DST database received error
DEBUG: Python function update_dst finished
```




## 1. Workaround: change retry interval

```deby@87f54d60e631:~/build$ rm downloads/CVE_CHECK/DEBIAN/dst.json; rm -rf tmp cache/ sstate-cache/; bitbake bash -c cve_check
Parsing recipes: 100% |####################################################################| Time: 0:00:11
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "update-packages-202502-cvecheck:cec6f0003b2bcd3ca38cb5fb40792c69fa909dc5"

Initialising tasks: 100% |#################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: bash-5.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-18276), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

Checked log.do_populate_cve_db:
```
DEBUG: Executing python function do_populate_cve_db
NOTE: CVE database recently updated, skipping
DEBUG: Python function do_populate_cve_db finished
DEBUG: Executing python function update_dst
NOTE: Download json file from https://deb.freexian.com/extended-lts/tracker/data/json
DEBUG: DST database: received error (HTTP Error 504: Gateway Time-out), retrying
DEBUG: DST database: received error (HTTP Error 503: Service Unavailable), retrying
DEBUG: DST database updated
DEBUG: Python function update_dst finished

```



## 2-1. Own mirror: append fallback URL

```
deby@87f54d60e631:~/build$ rm downloads/CVE_CHECK/DEBIAN/dst.json; rm -rf tmp cache/ sstate-cache/; bitbake busybox -c cve_check
Parsing recipes: 100% |####################################################################| Time: 0:00:11
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "update-packages-202502-cvecheck:cec6f0003b2bcd3ca38cb5fb40792c69fa909dc5"

Initialising tasks: 100% |#################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: busybox-1.30.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000500 CVE-2021-42374 CVE-2021-42376 CVE-2021-42378 CVE-2021-42379 CVE-2021-42380 CVE-2021-42381 CVE-2021-42382 CVE-2021-42384 CVE-2021-42385 CVE-2021-42386 CVE-2022-48174 CVE-2023-39810), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/busybox/1.30.1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There was 1 WARNING message shown.
```

Checked log.do_populate_cve_db:
```
DEBUG: Executing python function do_populate_cve_db
NOTE: CVE database recently updated, skipping
DEBUG: Python function do_populate_cve_db finished
DEBUG: Executing python function update_dst
NOTE: Download json file from https://deb.freexian.com/extended-lts/tracker/data/json
DEBUG: DST database: received error (HTTP Error 504: Gateway Time-out), retrying
NOTE: Download json file from http://localhost:8000/dst.json
DEBUG: DST database updated
DEBUG: Python function update_dst finished

```


## 2-2. Own mirror: change URL

```
deby@87f54d60e631:~/build$ rm downloads/CVE_CHECK/DEBIAN/dst.json; rm -rf tmp cache/ sstate-cache/; bitbake busybox -c cve_check
Parsing recipes: 100% |####################################################################| Time: 0:00:11
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "update-packages-202502-cvecheck:cec6f0003b2bcd3ca38cb5fb40792c69fa909dc5"

Initialising tasks: 100% |#################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: cve-update-nvd2-native-1.0-r0 do_populate_cve_db: Invalid URL (unknown url type: '')
WARNING: busybox-1.30.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000500 CVE-2021-42374 CVE-2021-42376 CVE-2021-42378 CVE-2021-42379 CVE-2021-42380 CVE-2021-42381 CVE-2021-42382 CVE-2021-42384 CVE-2021-42385 CVE-2021-42386 CVE-2022-48174 CVE-2023-39810), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/busybox/1.30.1-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```

Checked log.do_populate_cve_db:
```
DEBUG: Executing python function do_populate_cve_db
NOTE: CVE database recently updated, skipping
DEBUG: Python function do_populate_cve_db finished
DEBUG: Executing python function update_dst
NOTE: Download json file from
WARNING: Invalid URL (unknown url type: '')
NOTE: Download json file from http://localhost:8000/dst.json
DEBUG: DST database updated
DEBUG: Python function update_dst finished
deby@87f54d60e631:~/build$
```
