### PR TITLE
classes: Add kernel-cve-check.bbclass

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -58,6 +58,29 @@ python do_cve_check () {
     if os.path.exists(d.getVar("CVE_CHECK_DB_FILE")):
         patched_cves = get_patches_cves(d)
         patched, unpatched = check_cves(d, patched_cves)
+
+        # Callback to improve accuracy of check_cves() results.
+        #
+        # The CHECK_CVES_CALLBACK variable is registered with function names
+        # separated by spaces.
+        #
+        # [How to register callback function]
+        # Functions with the following arguments and return values can be
+        # registered to it.
+        #   example:
+        #     def example_func(d, patched, unpatched):
+        #         ...<feature to improve accuracy>...
+        #         return (patched, unpatched)
+        #
+        # Then, registered with:
+        #     CHECK_CVES_CALLBACK_append += "example_func"
+        callback_funcs = d.getVar("CHECK_CVES_CALLBACK")
+        bb.debug(2, "CHECK_CVES_CALLBACK: %s" % callback_funcs)
+        if isinstance(callback_funcs, str):
+            for callback_func in callback_funcs.split():
+                bb.note("Call to '%s' function." % callback_func)
+                patched, unpatched = eval(callback_func)(d, patched, unpatched)
+
         if patched or unpatched:
             cve_data = get_cve_info(d, patched + unpatched)
             cve_write_data(d, patched, unpatched, cve_data)

--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -20,7 +20,7 @@ python debian_cve_check () {
         bb.note("%s dosen't use debian source" % d.getVar("BPN"))
         return
 
-    json_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True),"dst.json")
+    json_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True), "dst.json")
     dst_data = load_json(json_path)
 
     # get package name from DEBIAN_SRC_URI
@@ -52,11 +52,11 @@ python update_dst () {
     from datetime import datetime, date
 
     json_urls = d.getVar("DEBIAN_SECRUTY_TRACKER_JSON_URL", "").split(" ")
-    dist_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True),"dst.json")
+    dist_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True), "dst.json")
     dist_dir = os.path.dirname(dist_path)
 
     if not os.path.isdir(dist_dir):
-        os.mkdir(dist_dir)
+        os.makedirs(dist_dir)
 
     if os.path.isfile(dist_path):
         timestamp = datetime.fromtimestamp(os.path.getmtime(dist_path))
@@ -132,8 +132,8 @@ def compare_versions(current_version, fixed_version):
     """
     import subprocess
 
-    ret = subprocess.run(["/usr/bin/dpkg","--compare-versions", current_version,
-                                        "ge",fixed_version]).returncode
+    ret = subprocess.run(["/usr/bin/dpkg", "--compare-versions", current_version,
+                                        "ge", fixed_version]).returncode
     if ret == 0:
         return True
     else:

--- a/classes/gitpkgv.bbclass
+++ b/classes/gitpkgv.bbclass
@@ -44,6 +44,11 @@ GITPKGVTAG = "${@get_git_pkgv(d, True)}"
 # groups will be concatenated to yield the final version.
 GITPKGV_TAG_REGEXP ??= "v(\d.*)"
 
+# This variable specifies options to git-describe command used to getting the tag name.
+# The default is `--exact-match`.
+# To get the closest tag name from a specified hash, specify `--abbrev=0`.
+GITPKGV_TAG_OPTION ??= "--exact-match"
+
 def gitpkgv_drop_tag_prefix(d, version):
     import re
 
@@ -108,8 +113,9 @@ def get_git_pkgv(d, use_tags):
 
                 if use_tags:
                     try:
+                        vars['opt'] = d.getVar('GITPKGV_TAG_OPTION')
                         output = bb.fetch2.runfetchcmd(
-                            "git --git-dir=%(repodir)s describe %(rev)s --tags --exact-match 2>/dev/null"
+                            "git --git-dir=%(repodir)s describe %(rev)s --tags %(opt)s 2>/dev/null"
                             % vars, d, quiet=True).strip()
                         ver = gitpkgv_drop_tag_prefix(d, output)
                     except Exception:

--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -1,0 +1,311 @@
+#
+# kernel-cve-check.bbclass
+#
+# This class checks fixed CVEs in kernel by using cip-kernel-sec
+# and adds them to the CVE_CHECK_WHITELIST before the cve_check runs.
+#
+# This class reads cip version from 'LINUX_CIP_VERSION' variable.
+# Set the version of cip kernel to be used in the variable.
+#
+# Example:
+#   LINUX_CIP_VERSION = 'v4.19.325-cip121'
+#
+# In order to use this class inherit this class in the local.conf
+# and run cve_check task.
+
+inherit cve-check
+
+KERNEL_CVE_CHECK_DIR ?= "${CVE_CHECK_DB_DIR}/KERNEL"
+
+# KERNEL_CVE_CHECK_INCLUDE_IGNORE:
+# - If value is "0":
+#   Consider ignore information, add CVEs that are registered as negligible to
+#   whitelist, then the CVE check result is "Patched".
+# - If value is "1" (default):
+#   Do not consider ignore information when performing CVE check using
+#   cip-kernel-sec tracking information.
+KERNEL_CVE_CHECK_INCLUDE_IGNORE ?= "1"
+
+# KERNEL_CVE_CHECK_SHOW_IGNORE_INFO:
+# - If value is "0" (default):
+#   Do not output ignore information.
+# - If value is "1":
+#   Add 'IGNORE INFO:' line to cve manifest.
+KERNEL_CVE_CHECK_SHOW_IGNORE_INFO ?= "0"
+
+# Remote branch name. bitbake detects it from kernel-src by default.
+KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO ??= ""
+KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT ??= "1"
+
+# It requires an initial value to ignore kernel cve check if PN is not kernel
+KERNEL_PN = "not_kernel"
+KERNEL_CVE_CHECK_TASK_ORDER = ""
+
+python() {
+    if d.getVar("PN") == d.getVar("PREFERRED_PROVIDER_virtual/kernel"):
+        d.setVar('KERNEL_PN', d.getVar('PN'))
+        d.setVar('KERNEL_CVE_CHECK_TASK_ORDER', '{}:do_unpack {}:do_prepare_recipe_sysroot'.format(d.getVar('KERNEL_PN'), d.getVar('KERNEL_PN')))
+}
+
+# Called back from do_cve_check() of cve-check.bbclass by registering it in the
+# CHECK_CVES_CALLBACK variable.
+def kernel_check_cves_func(d, patched, unpatched):
+    """
+    Correct the cve-check results with the kernel_cve_check() results.
+    """
+    if d.getVar("PN") == d.getVar("KERNEL_PN"):
+        cip_kernel_sec_affected_cves = d.getVar("CIP_KERNEL_SEC_AFFECTED_CVES")
+        if len(cip_kernel_sec_affected_cves) > 0:
+            tmp = cip_kernel_sec_affected_cves.split(" ")
+            for cve in tmp:
+                # Do not override cve-check result when cve is in patched list.
+                if not cve in unpatched and not cve in patched:
+                    unpatched.append(cve)
+
+            unpatched = sorted(unpatched)
+
+        cip_kernel_sec_fixed_cves = d.getVar("CIP_KERNEL_SEC_FIXED_CVES")
+        if len(cip_kernel_sec_fixed_cves) > 0:
+            tmp = cip_kernel_sec_fixed_cves.split(" ")
+            for cve in tmp:
+                if cve in unpatched:
+                    # in case cve-check thought this cve is unpatched but cip-kernel-sec said it's fixed
+                    idx = unpatched.index(cve)
+                    unpatched.pop(idx)
+                if not cve in patched:
+                    patched.append(cve)
+
+            patched = sorted(patched)
+
+    return (patched, unpatched)
+
+###############################################################################
+# update_cip_kernel_sec
+###############################################################################
+
+def remove_remote(workdir):
+    """
+    Remove needless remotes from remotes.yml.
+    """
+    import yaml
+
+    remotes_path = os.path.join(workdir, "remotes.yml")
+
+    with open(remotes_path) as f:
+        content = yaml.safe_load(f)
+
+    with open(remotes_path, "w") as f:
+        yaml.dump({"cip": content["cip"]}, f, default_flow_style=False)
+
+python update_cip_kernel_sec () {
+    """
+    Update cip-kernel-sec repository.
+    """
+    from bb.fetch2 import runfetchcmd
+
+    kernel_cve_check_dir = d.getVar("KERNEL_CVE_CHECK_DIR")
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
+    git_uri = "https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec.git"
+
+    if not os.path.isdir(kernel_cve_check_dir):
+        os.makedirs(kernel_cve_check_dir)
+
+    if not os.path.isdir(cip_kernel_sec_path):
+        # first run
+        runfetchcmd("git clone %s cip-kernel-sec" % git_uri, d,  workdir=kernel_cve_check_dir)
+
+    stdout, _ = bb.process.run('git ls-files -v conf/remotes.yml', cwd=cip_kernel_sec_path, shell=True)
+    if "S" != stdout.split()[0]:
+        # edit conf/remotes.yml
+        remove_remote(os.path.join(cip_kernel_sec_path, "conf"))
+        runfetchcmd("git update-index --skip-worktree conf/remotes.yml", d, workdir=cip_kernel_sec_path)
+
+    runfetchcmd("git pull", d, workdir=cip_kernel_sec_path)
+}
+
+do_populate_cve_db[postfuncs] += "update_cip_kernel_sec"
+
+###############################################################################
+# kernel_cve_check
+###############################################################################
+
+def get_issue_list(cip_kernel_sec_path):
+    """
+    Get issue list registered to cip-kernel-sec.
+    """
+    import glob
+    glob_param = cip_kernel_sec_path + "/issues/CVE-*.yml"
+
+    return [os.path.basename(name)[:-4] for name in glob.glob(glob_param)]
+
+python kernel_cve_check () {
+    """
+    Check cves by cip-kernel-sec
+    """
+    from bb.fetch2 import runfetchcmd
+    import requests
+    import bb.process
+    import yaml
+    import os
+    import tempfile
+
+    kernel_path = d.getVar("S")
+    linux_cip_ver = d.getVar("LINUX_CIP_VERSION")
+    kernel_cve_check_dir = d.getVar("KERNEL_CVE_CHECK_DIR")
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
+    include_ignore = d.getVar("KERNEL_CVE_CHECK_INCLUDE_IGNORE")
+    remote_repo_name = d.getVar("KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO")
+    remote_repo_autodetect = d.getVar("KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT")
+
+    if linux_cip_ver is None:
+        bb.error("LINUX_CIP_VERSION is not set. Please set version")
+        return
+
+    opt_ignore = "--include-ignored" if include_ignore == "1" else ""
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        output_filename = f.name
+
+    # Try to get remote name from kernel repository
+    if not remote_repo_name and remote_repo_autodetect == "1":
+        try:
+            bb.debug(2, "No remote name is defined and KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_AUTODETECT is set. bitbake detects remote name from kernel-src")
+            stdout, _ = bb.process.run('git remote', cwd=kernel_path, shell=True)
+            remote_repo_name = stdout.splitlines()[0]
+        except bb.process.ExecutionError as e:
+            bb.warn("Failed to detect remote name. bitbake assumes that remote is 'origin'. Please consider setting KERNEL_CVE_CHECK_LINUX_GIT_REMOTE_REPO")
+
+    cert_path = requests.certs.where()
+    cmdenv = "PYTHONPATH='%s' SSL_CERT_FILE='%s'" % (':'.join(sys.path), cert_path)
+    script = "python3 scripts/report_affected.py"
+    cmdopt = "%s --include-fixed --output-format=yaml --output-filename=%s --remote-name cip:%s --git-repo" % (opt_ignore, output_filename, remote_repo_name)
+    params = ' '.join([kernel_path, linux_cip_ver])
+    cmd = ' '.join([cmdenv, script, cmdopt, params])
+    bb.debug(2, "Run report_affected.py, cmd: %s" % cmd)
+    try:
+        runfetchcmd(cmd, d, workdir=cip_kernel_sec_path)
+    except bb.fetch2.FetchError as e:
+        bb.warn("Failed to run report_affected.py: %s" % (e))
+
+    fixed_cves = []
+    tmp_affected_cves = []
+    with open(output_filename) as f:
+        yaml_data = yaml.safe_load(f)
+        if yaml_data is not None:
+            k = list(yaml_data)[0]
+
+            # We don't need ignored data because CVEs in ignore section is not affected to this kernel version.
+            tmp_affected_cves.extend(yaml_data[k]["affected"])
+            fixed_cves = yaml_data[k]["fixed"]
+
+    os.unlink(output_filename)
+
+    whitelist = []
+    for cve in get_issue_list(cip_kernel_sec_path):
+        if cve not in tmp_affected_cves:
+            whitelist.append(cve)
+    whitelist = sorted(whitelist)
+
+    bb.debug(2, "Whitelisted by cip-kernel-sec:\n    %s" % "\n    ".join(whitelist))
+    d.appendVar("CVE_CHECK_WHITELIST", ' ' + ' '.join(whitelist))
+
+    safelist_str = d.getVar("CVE_CHECK_WHITELIST")
+    safelist = safelist_str.split(" ")
+
+    affected_cves = []
+    for cve in tmp_affected_cves:
+        if not cve in safelist:
+            affected_cves.append(cve)
+        else:
+            fixed_cves.append(cve)
+
+    d.setVar("CIP_KERNEL_SEC_AFFECTED_CVES", " ".join(affected_cves))
+    d.setVar("CIP_KERNEL_SEC_FIXED_CVES", " ".join(fixed_cves))
+
+    # Register to be called back from do_cve_check().
+    d.appendVar("CHECK_CVES_CALLBACK", "kernel_check_cves_func")
+}
+
+do_cve_check[prefuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'kernel_cve_check', '', d)}"
+do_cve_check[depends] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), d.getVar('KERNEL_CVE_CHECK_TASK_ORDER'), '', d)}"
+
+###############################################################################
+# write_ignore_info
+###############################################################################
+
+def get_ignore_info(cip_kernel_sec_path, cve_id, target_branch_name, d):
+    """
+    Get ignore reason for the cve_id.
+    """
+    import sys
+
+    sys.path.append(cip_kernel_sec_path + "/scripts")
+    import kernel_sec.issue
+
+    cwd = os.getcwd()
+    os.chdir(cip_kernel_sec_path)
+    issue = kernel_sec.issue.load(cve_id)
+    os.chdir(cwd)
+
+    ignore = issue.get('ignore', {})
+    for branch_name in ignore:
+        if branch_name == "all" or branch_name == target_branch_name:
+            return ignore[branch_name].replace('\n', ' ')
+    return None
+
+def insert_ignore_info(file_name, d):
+    """
+    Insert IGNORE INFO attribute.
+    """
+    if not os.path.isfile(file_name):
+        bb.error("%s is not found." % file_name)
+        return
+
+    # target_branch_name is a string like 'cip/4.19'
+    target_branch_name = ''
+    cip_ver = d.getVar("LINUX_CIP_VERSION")
+    if cip_ver:
+        target_branch_name = 'cip/' + '.'.join(cip_ver.split('.')[0:2]).replace('v', '')
+
+    kernel_cve_check_dir = d.getVar("KERNEL_CVE_CHECK_DIR")
+    cip_kernel_sec_path = os.path.join(kernel_cve_check_dir, "cip-kernel-sec")
+    issue_list = get_issue_list(cip_kernel_sec_path)
+
+    with open(file_name, "r") as f:
+        content = f.readlines()
+
+    for index, line in enumerate(content):
+        if line.startswith("PACKAGE NAME:"):
+            ignore_info = None
+            pkg_name = line.split()[2]
+        if line.startswith("CVE:") and pkg_name == d.getVar('KERNEL_PN'):
+            cve_id = line.split()[1]
+            if cve_id in issue_list:
+                ignore_info = get_ignore_info(cip_kernel_sec_path, cve_id, target_branch_name, d)
+        if line.startswith("MORE INFORMATION:") and ignore_info:
+            content.insert(index, "IGNORE INFO: %s\n" % ignore_info)
+            ignore_info = None
+
+    with open(file_name, "w") as f:
+        for line in content:
+            f.write(line)
+
+python write_ignore_info () {
+    """
+    Write ignore information to CVE manifest
+    """
+
+    cve_file = d.getVar("CVE_CHECK_LOG")
+
+    insert_ignore_info(cve_file, d)
+
+    if d.getVar("CVE_CHECK_COPY_FILES") == "1":
+        cve_dir = d.getVar("CVE_CHECK_DIR")
+        deploy_file = os.path.join(cve_dir, d.getVar("PN"))
+        insert_ignore_info(deploy_file, d)
+
+    if d.getVar("CVE_CHECK_CREATE_MANIFEST") == "1":
+        tmp_file = d.getVar("CVE_CHECK_TMP_FILE")
+        insert_ignore_info(tmp_file, d)
+}
+
+do_cve_check[postfuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'write_ignore_info', '', d) if d.getVar('KERNEL_CVE_CHECK_SHOW_IGNORE_INFO') == '1' else ''}"

--- a/classes/linux-src.bbclass
+++ b/classes/linux-src.bbclass
@@ -40,6 +40,11 @@ PV = "${LINUX_VERSION}+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 # use GITPKGVTAG for cve-check
+GITPKGV_TAG_REGEXP = "(.*)"
+GITPKGV_TAG_OPTION = "--abbrev=0"
 inherit gitpkgv
-do_cve_check[depends] += "linux-base:do_fetch"
-CVE_VERSION ??= "${@d.getVar('GITPKGVTAG').split('-')[0]}"
+do_cve_check[depends] += "virtual/kernel:do_fetch"
+CVE_VERSION ??= "${@oe.utils.conditional('LINUX_CIP_VERSION', '', d.getVar('PV'), d.getVar('LINUX_CIP_VERSION').split('-')[0].replace('v', ''), d)}"
+
+# If use cip_kernel, for kernel-cve-check
+LINUX_CIP_VERSION ??= "${@oe.utils.str_filter(r'(v\d.*-cip\d.*)', d.getVar('GITPKGVTAG'), d)}"

--- a/doc/1.getting_started.md
+++ b/doc/1.getting_started.md
@@ -45,7 +45,8 @@ $ git clone -b warrior https://github.com/meta-debian/meta-debian.git
       ```sh
       $ sudo apt-get install gawk wget git-core diffstat unzip texinfo gcc-multilib \
       build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
-      xz-utils debianutils iputils-ping
+      xz-utils debianutils iputils-ping openssh-client python3-debian python3-yaml \
+      python3-html5lib python3-requests
       ```
 
       NOTE: The following three packages have version limitation

--- a/doc/7.cve-check.md
+++ b/doc/7.cve-check.md
@@ -1,8 +1,15 @@
-# CVE Check feature
+# CVE Check feature for Debian packages
 
 The CVE check feature is based on Poky's CVE check functionality and uses NVD vulnerability information. However, the fixed versions listed in NVD vulnerability information may not match Debian package versions. As a result, relying solely on NVD vulnerability information could lead to Debian packages that have already been patched being mistakenly identified as unpatched. To address this issue, the CVE check feature in meta-debian utilizes Debian vulnerability information to eliminate false positives.
 
-# Variable
+## Usage
+
+Add the following line to local.conf to enable debian-cve-check:
+```
+INHERIT += " cve-check debian-cve-check"
+```
+
+## Variable
 
 - DEBIAN\_SECRUTY\_TRACKER\_JSON\_URL
 
@@ -22,3 +29,65 @@ Replace URL:
 DEBIAN_SECRUTY_TRACKER_JSON_URL = "http://localhost:8000/dst.json"
 ```
 
+
+# CVE Check feature for Kernel
+
+The CVE check feature for Kernel is also based on Poky's CVE checker and uses NVD vulnerability information. However, In NVD vulnerability information, may not be detected correctly if the score is 0 or CPE is unregistered. To address this issue, the CVE check feature for Kernel in meta-debian utilizes cip-kernel-sec tracking information to eliminate false positives, since the meta-debian kernel source code uses cip-kernel.
+
+## Usage
+
+Add the following line to local.conf to enable kernel-cve-check:
+```
+INHERIT += " cve-check kernel-cve-check"
+```
+
+## Variable
+
+- LINUX\_CIP\_VERSION
+
+Set the variable to the version of the cip kernel you are using. Specify if you are using the CIP kernel and if you want to use the information in cip-kernel-sec to perform CVE check. The default is set the CIP kernel version specified by LINUX_GIT_SRCREV in classes/linux-src.bbclass.
+
+Example:
+```
+LINUX_CIP_VERSION = 'v4.19.325-cip121'
+```
+
+- KERNEL\_CVE\_CHECK\_INCLUDE\_IGNORE
+
+Specifies whether to consider ignore information when performing CVE check using cip-kernel-sec tracking information.
+
+If value is "1" (default): Do not consider ignore information.
+
+If value is "0": Consider ignore information, add CVEs that are registered as negligible to whitelist, then the CVE check result is "Patched".
+
+Add the following line to local.conf to consider ignore information:
+```
+KERNEL_CVE_CHECK_INCLUDE_IGNORE = "0"
+```
+
+
+- KERNEL\_CVE\_CHECK\_SHOW\_IGNORE\_INFO
+
+Add ignore information of cip-kernel-sec to cve manifest.
+
+Default value is "0", which suppresses output.
+
+Set value to "1", add "IGNORE INFO:" line as shown below:
+
+```diff
+ PACKAGE NAME: linux-base
+ PACKAGE VERSION: 4.19+gitAUTOINC+1e9cb006c5
+ CVE: CVE-2008-2544
+ CVE STATUS: Unpatched
+ CVE SUMMARY: Mounting /proc filesystem via chroot command silently mounts it in read-write mode. The user could bypass the chroot environment and gain write access to files, he would never have otherwise.
+ CVSS v2 BASE SCORE: 2.1
+ CVSS v3 BASE SCORE: 5.5
+ VECTOR: LOCAL
++IGNORE INFO: non-issue
+ MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2008-2544
+```
+
+Add the following line to local.conf to add "IGNORE INFO:" line:
+```
+KERNEL_CVE_CHECK_SHOW_IGNORE_INFO = "1"
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,10 @@ RUN apt-get update && \
 	python3-pexpect xz-utils debianutils iputils-ping file locales \
 	openssh-client python3-debian
 
+# for kernel-cve-check.bbclass
+RUN apt-get install -y --no-install-recommends \
+	python3-yaml python3-html5lib python3-requests
+
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen
 RUN useradd -d $HOME -U -m -s /bin/bash -u $UID $USER
 RUN usermod -a -G sudo $USER


### PR DESCRIPTION
# Purpose of pull request

Add kernel-cve-check.bbclass for correctly detect cip-kernel vulnerabilities.

cve-check may not correctly detect kernel vulnerabilities if the NVD information score is 0 or if CPE is not set.

In meta-debian, Kernel source code uses cip-kernel. The cip-project[1] has a cip-kernel-sec[2] that tracks the status of security problems identified by CVE IDs.

So, add kernel-cve-check.bbclass, which complements the CVE check using information from cip-kernel-sec.

[1] https://www.cip-project.org/
[2] https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec


# Description of changes

Description of kernel-cve-check.bbclass:
- Use LINUX_CIP_VERSION variable Specifies the version of cip-kernel in use, for refer to cip-kernel-sec information. The default value of this variable is set in linux-src.bbclass.
- Process flow of kernel-cve-check:
  1. update_cip_kernel_sec() is called by `do_populate_cve_db[postfuncs]` Fetch cip-kernel-sec information.
  2. kernel_cve_check() is called by `do_cve_check[prefuncs]` Check Kernel's CVE using cip-kernel-sec information. Extracts CVEs affected in cip-kernel version specified by LINUX_CIP_VERSION variable, and set to CIP_KERNEL_SEC_AFFECTED_CVES and CIP_KERNEL_SEC_FIXED_CVES variables. And register 'kernel_check_cves_func' function to CHECK_CVES_CALLBACK variable for be called back after cve-check.
  3. kernel_check_cves_func() is called by callback from `do_cve_check` Called back by do_cve_check() in cve-check.bbclass after CVE checking using NVD information.

And the following improvements for add kernel-cve-check.bbclass:
- classes/cve-check.bbclass: Add callback for functions registered in the CHECK_CVES_CALLBACK variable, after check_cves() in do_cve_check task.
- classes/debian-cve-check.bbclass: Use os.makedirs() in case the DEBIAN_CVE_CHECK_DB_DIR variable is overwritten. And fix code style.
- classes/gitpkgv.bbclass: Add GITPKGV_TAG_OPTION to allow changing the option specify to `git describe`, for get closest tag name.
- classes/linux-src.bbclass:
  - Improve CVE_VERSION default value, because tag names cannot be retrieved if the hash has no tags set (HEAD does not always have a tag set)
  - do_cve_check[depend] changed to `virtual/kernel:do_fetch` instead of `linux-base:do_fetch`, considering the possibility of Kernel recipe name changes in upper layers
- doc/7.cve-check.md: Added explanation for kernel-cve-check and improved debian-cve-check chapter accordingly.
- docker/Dockerfile: Add package installation of Python3 modules used by kernel-cve-check.bbclass.


# Test
## How to test

1. Start the Docker build environment

   This PR modifie the Dockerfile, need to rebuild the Docker image using 'make refresh', only required the first time.
   ```
   $ cd poky/meta-debian/docker
   $ make refresh
   $ make start
   ```

2. Setup the build environment
   ```
   $ export TEMPLATECONF=meta-debian/conf
   $ source ./poky/oe-init-build-env
   ```

3. Setting to local.conf

   Add following line into conf/local.conf.
   Comment out INHERIT as we will use it later.
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   #INHERIT += " cve-check kernel-cve-check"
   ```

   Since this PR targets the kernel, for Debian packages follow doc/6.security-update.md to enable security updates.
   ```
   DEBIAN_SOURCE_ENABLED = "1"
   DEBIAN_SRC_FORCE_REGEN = "1"
   DEBIAN_SECURITY_UPDATE_ENABLED = "1"
   ```

4. Check core-image-minimal build

   Keep commented out the INHERIT line in local.conf.
   Run the following command to build core-image-minimal.
   ```
   $ bitbake core-image-minimal
   ```

5. Check bitbake variables

   Keep commented out the INHERIT line in local.conf.
   Run the following command for check bitbake variables.
   ```
   $ bitbake -e linux-base -c cve_check | grep -e "LINUX_VERSION=" -e "CVE_VERSION=" -e "LINUX_CIP_VERSION=" -e "PV=" -e "PKGV=" -e "GITPKGVTAG="
    ```

   Check the variables before and after applying this PR.

6. Run Kernel CVE check

   After setting INHERIT in local.conf as described later, run the following command for CVE checks of kernel.
   ```
   $ bitbake linux-base -c cve_check
   ```

   Compare CVE check results with and without "kernel-cve-check" in INHERIT on local.conf.
   In other words, as follows:
   - for with:
     ```
     INHERIT += " cve-check kernel-cve-check"
     ```
   - for without:
     ```
     INHERIT += " cve-check"
     ```

7. Run Kernel CVE check considering ignore information

   Set "kernel-cve-check" to INHERIT in local.conf.
   ```
   INHERIT += " cve-check kernel-cve-check"
   ```

   Add following line into conf/local.conf as definition that consider ignore information.
   ```
   KERNEL_CVE_CHECK_INCLUDE_IGNORE = "0"
   KERNEL_CVE_CHECK_SHOW_IGNORE_INFO = "1"
   ```

   Compare CVE check results with default setting and this setting.

# Test result
## 4. Check core-image-minimal build

The build of core-image-minimal was successful.
```
build$ bitbake core-image-minimal 
WARNING: debian security update repository is enabled
WARNING: debian ELTS security update repository is enabled
Checking Debian Release ... http://deb.freexian.com/extended-lts/dists/buster-lts/Release
Fetching Debian Sources.gz ... http://deb.freexian.com/extended-lts/dists/buster-lts/main/source/Sources.gz;md5sum=07ac90a4ca03d17a967a53e8475f1116
Parsing Debian Sources.gz ...
Checking Debian Release ... http://archive.debian.org/debian-security/dists/buster/updates/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian-security/dists/buster/updates/main/source/Sources.gz;md5sum=e3bb28be0cf1fb769d3c63c037fc5bf8
Parsing Debian Sources.gz ...
Checking Debian Release ... http://archive.debian.org/debian/dists/buster/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian/dists/buster/main/source/Sources.gz;md5sum=60b1a2c60363095f2871f4a056e36980
Parsing Debian Sources.gz ...
Parsing recipes: 100% |#################################################################################################| Time: 0:00:04
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 74 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "add-kernel-cve-check:0723c09a01d9088063f04700b3ad1677d1f5f717"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 842 Found 0 Missed 842 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2965 tasks of which 5 didn't need to be rerun and all succeeded.

Summary: There were 2 WARNING messages shown.
```

## 5. Check bitbake variables

Before applying this PR, CVE_VERSION was not set because the HEAD of the Kernel source code was not tagged.
After applying this PR, the tag closest to HEAD is obtained and CVE_VERSION and LINUX_CIP_VERSION are set correctly.

### After applying this PR

```
build$ bitbake -e linux-base -c cve_check | grep -e "LINUX_VERSION=" -e "CVE_VERSION=" -e "LINUX_CIP_VERSION=" -e "PV=" -e "PKGV=" -e "GITPKGVTAG="
CVE_VERSION="4.19.325"
EXTENDPKGV="4.19+gitAUTOINC+6ea7b609a0-r0"
GITPKGV="816480+6ea7b60"
GITPKGVTAG="v4.19.325-cip124"
LINUX_CIP_VERSION="v4.19.325-cip124"
LINUX_VERSION="4.19"
PKGV="4.19+gitAUTOINC+6ea7b609a0"
PV="4.19+gitAUTOINC+6ea7b609a0"
SRCPV="AUTOINC+6ea7b609a0"
```

### Before applying this PR

```
build$ bitbake -e linux-base -c cve_check | grep -e "LINUX_VERSION=" -e "CVE_VERSION=" -e "LINUX_CIP_VERSION=" -e "PV=" -e "PKGV=" -e "GITPKGVTAG="
CVE_VERSION="4.19.325"
EXTENDPKGV="4.19+gitAUTOINC+6ea7b609a0-r0"
GITPKGV="816480+6ea7b60"
GITPKGVTAG="4.19.325-cip124"
LINUX_VERSION="4.19"
PKGV="4.19+gitAUTOINC+6ea7b609a0"
PV="4.19+gitAUTOINC+6ea7b609a0"
SRCPV="AUTOINC+6ea7b609a0"
```

### For reference

To check for cases where the cip-kernel hash does not have a tag, add the following to local.conf:
```
LINUX_GIT_SRCREV = "fbbced393b4a8d961b58b6807cbb45676ac90156"
```

Excerpt from the kernel commit history:
```
35cf17fa7360 signal/m68k: Use force_sigsegv(SIGSEGV) in fpsp040_die
f1811faa67f4 mmc: sdhci: Do not lock spinlock around mmc_gpio_get_ro()
fbbced393b4a x86/bugs: fix backport error in "x86/bugs: Don't fill RSB on VMEXIT with eIBRS+retpoline"
c49c4fbf2fa4 x86/bugs: fix backport error in "x86/bugs: Don't fill RSB on VMEXIT with eIBRS+retpoline"
3237eeb37d4b (tag: v4.19.325-cip121) CIP: Bump version suffix to -cip121 after merge from cip/linux-4.19.y-st tree
7e9e85988094 Merge branch 'linux-4.19.y-st' into linux-4.19.y-cip
e00abfb443ca (tag: v4.19-st5) Update localversion-st, tree is up-to-date with 5.4.293.
127e4ee2c5d9 x86/bugs: Don't fill RSB on VMEXIT with eIBRS+retpoline
0aa36fa45e3b clk: check for disabled clock-provider in of_clk_get_hw_from_clkspec()
```

#### Result when specifying hash without tag:
After applying this PR, the tag closest to SRCREV is obtained and CVE_VERSION and LINUX_CIP_VERSION are set correctly.

After applying this PR:
```
build$ bitbake -e linux-base -c cve_check | grep -e "LINUX_VERSION=" -e "CVE_VERSION=" -e "LINUX_CIP_VERSION=" -e "PV=" -e "PKGV=" -e "GITPKGVTAG="
CVE_VERSION="4.19.325"
EXTENDPKGV="4.19+gitAUTOINC+fbbced393b-r0"
GITPKGV="815727+fbbced3"
GITPKGVTAG="v4.19.325-cip121"
LINUX_CIP_VERSION="v4.19.325-cip121"
LINUX_VERSION="4.19"
PKGV="4.19+gitAUTOINC+fbbced393b"
PV="4.19+gitAUTOINC+fbbced393b"
SRCPV="AUTOINC+fbbced393b"
```

Before applying this PR:
```
build$ bitbake -e linux-base -c cve_check | grep -e "LINUX_VERSION=" -e "CVE_VERSION=" -e "LINUX_CIP_VERSION=" -e "PV=" -e "PKGV=" -e "GITPKGVTAG="
CVE_VERSION="0.0"
EXTENDPKGV="4.19+gitAUTOINC+fbbced393b-r0"
GITPKGV="815727+fbbced3"
GITPKGVTAG="0.0-815727-gfbbced3"
LINUX_VERSION="4.19"
PKGV="4.19+gitAUTOINC+fbbced393b"
PV="4.19+gitAUTOINC+fbbced393b"
SRCPV="AUTOINC+fbbced393b"
```

## 6. Run Kernel CVE check

Save /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+6ea7b609a0-r0/temp/cve.log as with-kernel-cve-check.log and without-kernel-cve-check.log respectively.

- [with-kernel-cve-check.log](https://github.com/user-attachments/files/22508921/with-kernel-cve-check.log)
- [without-kernel-cve-check.log](https://github.com/user-attachments/files/22508923/without-kernel-cve-check.log)

Since the difference is large, it is converted with the conv.sh script.

<details>
  <summary>“conv.sh” script:</summary>

```
#!/bin/bash

cvelist=$1
if [ "$#" -ne 1 ] || ! [ -f "$cvelist" ]; then
    echo "Usage: $0 <cve.log>"
    exit
fi
tmpfile="$1.tmp"
output="$1.output"

if [ -f $output ]; then
    rm "$output"
fi

pkg_name=""
pkg_version=""
cve_id=""
cve_status=""
while read line; do
    case "$line" in
    *:*)
        key=`echo "${line}" | cut -s -d: -f1`
        val=`echo "${line}" | cut -s -d: -f2`
        key=`echo -e $key`
        val=`echo -e $val`
        case "$key" in
        "PACKAGE NAME")
            pkg_name="$val"
            pkg_version=""
            cve_id=""
            cve_status=""
            ;;
        "PACKAGE VERSION")
            pkg_version="$val";;
        "CVE")
            if [ -z "${cve_id}" ]; then
                cve_id="$val"
            fi
            ;;
        "CVE STATUS")
            cve_status="$val";;
        "MORE INFORMATION")
            if [ -n "$cve_id" ]; then
                echo "$cve_id, $cve_status, $pkg_name, $pkg_version" >> $tmpfile
            fi
            ;;
        esac;;
    *)
    esac
done < $cvelist

cat $tmpfile | sort > $output
rm $tmpfile
echo "## CVE List convert success: $output"
```
</details>

Convert the log using the “conv.sh” script as follows:
```
$ ./conv.sh ./with-kernel-cve-check.log
$ ./conv.sh ./without-kernel-cve-check.log
```

Count of CVEs affected by kernel-cve-check:
```
$ diff -up ./without-kernel-cve-check.log.output ./with-kernel-cve-check.log.output | grep '^-CVE-' -c
1211
$ diff -up ./without-kernel-cve-check.log.output ./with-kernel-cve-check.log.output | grep '^+CVE-' -c
4884
```

### Verification of CVE check results

Picked out a couple of CVEs that matched the following three patterns from the output-file, and verified them. 

Detected three pattern by comparing output-file:
- CVE changed from unpatched to patched
- CVE chenged from undetected to patched
- CVE changed from undetected to unpatched


#### CVE changed from unpatched to patched

For the extracted CVE-2024-58083 and CVE-2025-39735, the currently used kernel version is cip-kernel-sec's “fixed-version” or later, so the CVE check results for these are “Patched”. 

```diff
$ diff -up ./without-kernel-cve-check.log.output ./with-kernel-cve-check.log.output | grep -e CVE-2025-39735 -e CVE-2024-58083
-CVE-2024-58083, Unpatched, linux-base, 4.19+gitAUTOINC+6ea7b609a0
+CVE-2024-58083, Patched, linux-base, 4.19+gitAUTOINC+6ea7b609a0
-CVE-2025-39735, Unpatched, linux-base, 4.19+gitAUTOINC+6ea7b609a0
+CVE-2025-39735, Patched, linux-base, 4.19+gitAUTOINC+6ea7b609a0
```

- CVE-2024-58083
  - NVD: https://nvd.nist.gov/vuln/detail/CVE-2024-58083
    Base Score: `7.8 HIGH`
    `cpe:2.3:o:linux:linux_kernel:4.19.325:*:*:*:*:*:*:*`
  - cip-kernel-sec: https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec/-/blob/master/issues/CVE-2024-58083.yml
    `fixed-version: v4.19.325-cip119`

- CVE-2025-39735
  - NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-39735
    Base Score:  `7.1 HIGH`
    `cpe:2.3:o:linux:linux_kernel:4.19.325:*:*:*:*:*:*:*`
  - cip-kernel-sec: https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec/-/blob/master/issues/CVE-2025-39735.yml
    `fixed-version: v4.19.325-cip120`

### CVE chenged from undetected to patched

For the extracted CVE-2024-58237 and CVE-2025-40364, it was not detected because score and CPE are not set in NVD,  then currently used kernel version is earlier than the 'introduced-version" in cip-kernel-sec, so the CVE check results for these are “Patched”. 

```diff
$ diff -up ./without-kernel-cve-check.log.output ./with-kernel-cve-check.log.output | grep -e CVE-2025-40364 -e CVE-2024-58237
+CVE-2024-58237, Patched, linux-base, 4.19+gitAUTOINC+6ea7b609a0
+CVE-2025-40364, Patched, linux-base, 4.19+gitAUTOINC+6ea7b609a0
```

- CVE-2024-58237
  - NVD: https://nvd.nist.gov/vuln/detail/CVE-2024-58237
    Score and CPE are not set.
  - cip-kernel-sec: https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec/-/blob/master/issues/CVE-2024-58237.yml
    `introduced-version: mainline: [v5.6-rc1]`

- CVE-2025-40364
  - NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-40364
    Score and CPE are not set.
  - cip-kernel-sec: https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec/-/blob/master/issues/CVE-2025-40364.yml
    `introduced-version: mainline: [v5.19-rc1]`

### CVE changed from undetected to unpatched

For the extracted CVE-2024-8805 and CVE-2025-40300, it was not detected because score and CPE are not set or not 'linux_kernel' of CPE in NVD, then currently used kernel version is newer than the 'introduced-version" in cip-kernel-sec and not yet fixed, so the CVE check results for these are “Unpatched”. 

```diff
$ diff -up ./without-kernel-cve-check.log.output ./with-kernel-cve-check.log.output | grep -e CVE-2024-8805 -e CVE-2025-40300
+CVE-2024-8805, Unpatched, linux-base, 4.19+gitAUTOINC+6ea7b609a0
+CVE-2025-40300, Unpatched, linux-base, 4.19+gitAUTOINC+6ea7b609a0
```

- CVE-2024-8805
  - NVD: https://nvd.nist.gov/vuln/detail/CVE-2024-8805
    Base Score: `8.8 HIGH`
    `cpe:2.3:a:bluez:bluez:5.77:*:*:*:*:*:*:*`
  - cip-kernel-sec: https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec/-/blob/master/issues/CVE-2024-8805.yml
    `introduced-version: mainline: [v3.16-rc3]`, and not yet fixed.

- CVE-2025-40300
  - NVD: https://nvd.nist.gov/vuln/detail/CVE-2025-40300
    Score and CPE are not set.
  - cip-kernel-sec: https://gitlab.com/cip-project/cip-kernel/cip-kernel-sec/-/blame/master/issues/CVE-2025-40300.yml
    'introduced-version' is not set and not yet fixed.


## 7. Run Kernel CVE check considering ignore information

Save /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+6ea7b609a0-r0/temp/cve.log as with-kernel-ignore-info-cve-check.log.

- [with-kernel-ignore-info-cve-check.log](https://github.com/user-attachments/files/22510379/with-kernel-ignore-info-cve-check.log)

Compared with-kernel-cve-check.log and with-kernel-ignore-info-cve-check.log, confirmed that 'IGNORE INFO:' line was added and 'CVE STATUS:' changed to 'Patched'.

```diff
$ diff -up ./with-kernel-cve-check.log ./with-kernel-ignore-info-cve-check.log | head -n 30
--- ./with-kernel-cve-check.log	2025-09-24 16:52:09.000000000 +0900
+++ ./with-kernel-ignore-info-cve-check.log	2025-09-24 18:17:24.000000000 +0900
@@ -4751,11 +4751,12 @@ MORE INFORMATION: https://nvd.nist.gov/v
 PACKAGE NAME: linux-base
 PACKAGE VERSION: 4.19+gitAUTOINC+6ea7b609a0
 CVE: CVE-2008-2544
-CVE STATUS: Unpatched
+CVE STATUS: Patched
 CVE SUMMARY: Mounting /proc filesystem via chroot command silently mounts it in read-write mode. The user could bypass the chroot environment and gain write access to files, he would never have otherwise.
 CVSS v2 BASE SCORE: 2.1
 CVSS v3 BASE SCORE: 5.5
 VECTOR: LOCAL
+IGNORE INFO: non-issue
 MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2008-2544
 
 PACKAGE NAME: linux-base
@@ -13286,6 +13287,7 @@ CVE SUMMARY: Heap-based buffer overflow
 CVSS v2 BASE SCORE: 9.3
 CVSS v3 BASE SCORE: 7.8
 VECTOR: NETWORK
+IGNORE INFO: Not affected
 MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2015-0569
 
 PACKAGE NAME: linux-base
@@ -13296,6 +13298,7 @@ CVE SUMMARY: Stack-based buffer overflow
 CVSS v2 BASE SCORE: 9.3
 CVSS v3 BASE SCORE: 7.8
 VECTOR: NETWORK
+IGNORE INFO: Not affected
 MORE INFORMATION: https://nvd.nist.gov/vuln/detail/CVE-2015-0570
```

Convert the log using the “conv.sh” script as follows (See step 6 for scripts):
```
$ ./conv.sh with-kernel-ignore-info-cve-check.log
```

Count of CVEs affected by variables considering ignore information:
```
$ diff -up ./with-kernel-cve-check.log.output ./with-kernel-ignore-info-cve-check.log.output | grep '^-CVE-' -c
265
$ diff -up ./with-kernel-cve-check.log.output ./with-kernel-ignore-info-cve-check.log.output | grep '^+CVE-' -c
130
```
