### PR TITLE
docker/Dockerfile: Change package repository to archive

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,7 @@ ENV POKY_GIT_URL https://git.yoctoproject.org/git/poky
 ENV POKY_REV warrior
 
 RUN bash -c 'if test -n "$http_proxy"; then echo "Acquire::http::proxy \"$http_proxy\";" > /etc/apt/apt.conf.d/99proxy; fi'
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
 RUN apt-get update && \
     apt-get install -y --no-install-recommends sudo iptables \
 	gawk wget git-core diffstat unzip texinfo gcc-multilib \


### PR DESCRIPTION
# Purpose of pull request
Change the package repository referenced in the Docker environment to 'archive.debian.org'.

Note:
---
Before this commit, the following error occurred:
```
Reading package lists...
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
```

# Test
Confirmed that the Docker environment started up.
```
meta-debian/docker$ make start
docker-compose run work
...<snip>...
Step 11/35 : RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
 ---> Running in 175db1d588c3
 ---> Removed intermediate container 175db1d588c3
 ---> 567182d1a665
...<snip>...
Creating docker_work_run ... done
deby@1a86e5c3a45c:~$ cat /etc/apt/sources.list
# deb http://snapshot.debian.org/archive/debian/20240612T000000Z buster main
deb http://archive.debian.org/debian buster main
# deb http://snapshot.debian.org/archive/debian-security/20240612T000000Z buster/updates main
deb http://archive.debian.org/debian-security buster/updates main
# deb http://snapshot.debian.org/archive/debian/20240612T000000Z buster-updates main
deb http://archive.debian.org/debian buster-updates main
```