### PR TITLE
debian-cve-check: Trust DST information over NVD information

### DIFF
--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -11,6 +11,33 @@ DEBIAN_CVE_CHECK_DB_DIR ?= "${CVE_CHECK_DB_DIR}/DEBIAN"
 DEBIAN_CODENAME ?= "${DISTRO_CODENAME}"
 DEBIAN_SECRUTY_TRACKER_JSON_URL ??= "https://deb.freexian.com/extended-lts/tracker/data/json"
 
+# Called back from do_cve_check() of cve-check.bbclass by registering it in the
+# CHECK_CVES_CALLBACK variable.
+def debian_check_cves_func(d, patched, unpatched):
+    """
+    Correct the cve-check results with the debian_cve_check() results.
+    """
+    dst_patched = d.getVar("DST_PATCHED_CVES")
+    if dst_patched is not None and len(dst_patched) > 0:
+        tmp = dst_patched.split(" ")
+        for cve in tmp:
+            if cve in unpatched:
+                idx = unpatched.index(cve)
+                unpatched.pop(idx)
+            if not cve in patched:
+                patched.append(cve)
+        patched = sorted(patched)
+
+    dst_unpatched = d.getVar("DST_UNPATCHED_CVES")
+    if dst_unpatched is not None and len(dst_unpatched) > 0:
+        tmp = dst_unpatched.split(" ")
+        for cve in tmp:
+            if not cve in unpatched and not cve in patched:
+                unpatched.append(cve)
+        unpatched = sorted(unpatched)
+
+    return (patched, unpatched)
+
 python debian_cve_check () {
     """
     Check CVE in Debian source
@@ -18,6 +45,11 @@ python debian_cve_check () {
     debian_src_uri = d.getVar("DEBIAN_SRC_URI", True)
     if debian_src_uri is None:
         bb.note("%s dosen't use debian source" % d.getVar("BPN"))
+        return
+
+    # Following policy in cve-check.bbclass, skip if CVE_PRODUCT has been unset
+    if not d.getVar("CVE_PRODUCT"):
+        bb.debug(2, "Skip debian-cve-check because CVE_PRODUCT is unset.")
         return
 
     json_path = os.path.join(d.getVar("DEBIAN_CVE_CHECK_DB_DIR", True), "dst.json")
@@ -36,8 +68,21 @@ python debian_cve_check () {
 
     deb_patched, deb_unpatched = deb_check_cves(d, dst_data[pkgname])
 
+    cve_whitelist = set(d.getVar("CVE_CHECK_WHITELIST").split())
+
+    for cve_id in deb_unpatched[:]:
+        if cve_id in cve_whitelist:
+            deb_unpatched.remove(cve_id)
+            deb_patched.append(cve_id)
+
     bb.debug(2, "Whitelisted by DST:\n    %s" % "\n    ".join(deb_patched))
+    bb.debug(2, "Unpatched CVE(s) found by DST:\n    %s" % "\n    ".join(deb_unpatched))
     d.appendVar("CVE_CHECK_WHITELIST", ' ' + ' '.join(deb_patched))
+    d.setVar("DST_PATCHED_CVES", ' '.join(deb_patched))
+    d.setVar("DST_UNPATCHED_CVES", ' '.join(deb_unpatched))
+
+    # Register to be called back from do_cve_check().
+    d.appendVar("CHECK_CVES_CALLBACK", "debian_check_cves_func")
 }
 
 do_cve_check[prefuncs] += "debian_cve_check"


### PR DESCRIPTION
# Purpose of pull request

In CVE checks for Debian packages, previously, Debian Security Tracker (DST) information was used only for CVEs detected by NVD information, so the cve-check could not correctly detect vulnerabilities with score was 0 or the CPE was not set on NVD information.

Going forward, DST information will be used regardless of detection by NVD information.

debian-cve-check results are merged to cve-check results (from NVD information), in callback function debian_check_cves_func() it is called from `do_cve_check`.

# Test
## How to test

1. Start the Docker build environment
   ```
   $ cd poky/meta-debian/docker
   $ make start
   ```

2. Setup the build environment
   ```
   $ export TEMPLATECONF=meta-debian/conf
   $ source ./poky/oe-init-build-env
   ```

3. Setting to local.conf

   Add following line into conf/local.conf.
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   INHERIT += " cve-check debian-cve-check kernel-cve-check"
   ```
   (Optional) If do_fetch error occurs of the debian package, follow doc/6.security-update.md to enable security updates.
   ```
   DEBIAN_SOURCE_ENABLED = "1"
   DEBIAN_SRC_FORCE_REGEN = "1"
   DEBIAN_SECURITY_UPDATE_ENABLED = "1"
   ```

4. Check core-image-minimal build and CVE checks

   Run the following command to build core-image-minimal and CVE checks.
   ```
   $ bitbake core-image-minimal
   ```

5. Check to CVE check results

   Save the CVE check results (`build/tmp/deploy/images/qemuarm64/core-image-minimal-qemuarm64.cve`) as `before.log` and `after.log`, respectively before and after applying this PR.

   Since the difference is large, it is converted with the conv.sh script.
   <details>
   <summary>“conv.sh” script:</summary>

   ```
   #!/bin/bash
   
   cvelist=$1
   if [ "$#" -ne 1 ] || ! [ -f "$cvelist" ]; then
       echo "Usage: $0 <cve.log>"
       exit
   fi
   tmpfile="$1.tmp"
   output="$1.output"
   
   if [ -f $output ]; then
       rm "$output"
   fi
   
   pkg_name=""
   pkg_version=""
   cve_id=""
   cve_status=""
   while read line; do
       case "$line" in
       *:*)
           key=`echo "${line}" | cut -s -d: -f1`
           val=`echo "${line}" | cut -s -d: -f2`
           key=`echo -e $key`
           val=`echo -e $val`
           case "$key" in
           "PACKAGE NAME")
               pkg_name="$val"
               pkg_version=""
               cve_id=""
               cve_status=""
               ;;
           "PACKAGE VERSION")
               pkg_version="$val";;
           "CVE")
               if [ -z "${cve_id}" ]; then
                   cve_id="$val"
               fi
               ;;
           "CVE STATUS")
               cve_status="$val";;
           "MORE INFORMATION")
               if [ -n "$cve_id" ]; then
                   echo "$cve_id, $cve_status, $pkg_name, $pkg_version" >> $tmpfile
               fi
               ;;
           esac;;
       *)
       esac
   done < $cvelist
   
   cat $tmpfile | sort > $output
   rm $tmpfile
   echo "## CVE List convert success: $output"
   ```
   </details>

   Convert the log using the “conv.sh” script as follows:
   ```
   $ ./conv.sh ./before.log
   $ ./conv.sh ./after.log
   ```

   Then, compare `before.log.output` and `after.log.output` files converted by conv.sh to check the defferences.

6. Check to recipes with unset CVE_PRODUCT skipped cve-check

  Check the target recipe:
  ```
  $ cd /home/deby/poky
  $ grep -r -n 'CVE_PRODUCT = ""'
  ```

  Check target recipes skipped cve-check:
  ```
  $ cd /home/deby/build
  $ cat ./tmp/work/aarch64-deby-linux/<target-recipe>/<version>/temp/log.do_cve_check
  ```

  Check to target recipe is not included in CVE report:
  ```
  $ grep -c '<target-recipe>' ./before.log
  $ grep -c '<target-recipe>' ./after.log
  ```

## Test result
### Check core-image-minimal build and CVE checks
The build of core-image-minimal was successful and CVE check was performed.
```
deby@be15cecd17af:~/build$ bitbake core-image-minimal
Parsing recipes: 100% |#################################################################################################| Time: 0:00:03
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "universal"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "trust-DST-info-over-NVD-info:9debf089cc55bc3a9ef121825fe54e8de597d4dd"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 2 Found 0 Missed 2 Current 841 (0% match, 99% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: flex-2.6.4-r0 do_cve_check: Found unpatched CVE (CVE-2015-1773 CVE-2019-6293), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/flex/2.6.4-r0/temp/cve.log
WARNING: patchelf-native-0.9-r0 do_cve_check: Found unpatched CVE (CVE-2022-44940), for more information check /home/deby/build/tmp/work/x86_64-linux/patchelf-native/0.9-r0/temp/cve.log
WARNING: bison-3.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2020-14150), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/bison/3.3.2-r0/temp/cve.log
WARNING: gawk-4.2.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-4156), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/gawk/4.2.1-r0/temp/cve.log
WARNING: unzip-6.0-r0 do_cve_check: Found unpatched CVE (CVE-2021-4217), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/unzip/6.0-r0/temp/cve.log
WARNING: gcc-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/gcc/8.3.0-r0/temp/cve.log
WARNING: iptables-1.8.2-r0 do_cve_check: Found unpatched CVE (CVE-2019-11360), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/iptables/1.8.2-r0/temp/cve.log
WARNING: binutils-2.31.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-17358 CVE-2018-17359 CVE-2018-17360 CVE-2018-20623 CVE-2018-20651 CVE-2018-20657 CVE-2018-20671 CVE-2018-20673 CVE-2018-20712 CVE-2019-1010180 CVE-2019-1010204 CVE-2020-19724 CVE-2020-21490 CVE-2020-35342 CVE-2020-35493 CVE-2020-35494 CVE-2020-35495 CVE-2020-35496 CVE-2020-35507 CVE-2021-20197 CVE-2021-3826 CVE-2021-45078 CVE-2021-46174 CVE-2021-46195 CVE-2022-38533 CVE-2022-44840 CVE-2022-45703 CVE-2022-47673 CVE-2022-47695 CVE-2022-47696 CVE-2022-48063 CVE-2022-48064 CVE-2022-48065 CVE-2023-25584 CVE-2024-53589 CVE-2024-57360 CVE-2025-0840 CVE-2025-5244 CVE-2025-5245), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/binutils/2.31.1-r0/temp/cve.log
WARNING: shadow-4.5-r0 do_cve_check: Found unpatched CVE (CVE-2007-5686 CVE-2013-4235 CVE-2024-56433), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/shadow/4.5-r0/temp/cve.log
WARNING: expat-2.2.6-r0 do_cve_check: Found unpatched CVE (CVE-2013-0340 CVE-2023-52426 CVE-2024-28757 CVE-2024-8176 CVE-2025-59375), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/expat/2.2.6-r0/temp/cve.log
WARNING: libxml2-2.9.4-r0 do_cve_check: Found unpatched CVE (CVE-2025-8732), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/libxml2/2.9.4-r0/temp/cve.log
WARNING: sqlite3-3_3.27.2-r0 do_cve_check: Found unpatched CVE (CVE-2019-19645 CVE-2020-11656 CVE-2020-13631 CVE-2022-35737 CVE-2025-52099 CVE-2025-6965), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/sqlite3/3_3.27.2-r0/temp/cve.log
WARNING: procps-3.3.15-r0 do_cve_check: Found unpatched CVE (CVE-2018-1121 CVE-2023-4016), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/procps/3.3.15-r0/temp/cve.log
WARNING: re2c-native-1.1.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-21232), for more information check /home/deby/build/tmp/work/x86_64-linux/re2c-native/1.1.1-r0/temp/cve.log
WARNING: coreutils-8.30-r0 do_cve_check: Found unpatched CVE (CVE-2016-2781 CVE-2025-5278), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/coreutils/8.30-r0/temp/cve.log
WARNING: libpcre-8.39-r0 do_cve_check: Found unpatched CVE (CVE-2019-20838 CVE-2020-14155), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/libpcre/8.39-r0/temp/cve.log
WARNING: bash-completion-2.8-r0 do_cve_check: Found unpatched CVE (CVE-2018-7738), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/bash-completion/2.8-r0/temp/cve.log
WARNING: bash-5.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-18276), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/cve.log
WARNING: mdadm-4.1-r0 do_cve_check: Found unpatched CVE (CVE-2023-28736 CVE-2023-28938), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/mdadm/4.1-r0/temp/cve.log
WARNING: socat-1.7.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2024-54661), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/socat/1.7.3.2-r0/temp/cve.log
WARNING: tar-1.30-r0 do_cve_check: Found unpatched CVE (CVE-2019-9923 CVE-2021-20193 CVE-2022-48303 CVE-2025-45582), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/tar/1.30-r0/temp/cve.log
WARNING: openssl-1.1.1n-r0 do_cve_check: Found unpatched CVE (CVE-2024-13176 CVE-2025-27587 CVE-2025-9230), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/openssl/1.1.1n-r0/temp/cve.log
WARNING: zip-3.0-r0 do_cve_check: Found unpatched CVE (CVE-2018-13410), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/zip/3.0-r0/temp/cve.log
WARNING: perl-5.28.1-r1 do_cve_check: Found unpatched CVE (CVE-2011-4116 CVE-2023-31486 CVE-2025-40909), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/perl/5.28.1-r1/temp/cve.log
WARNING: python3-3.7.3-r0 do_cve_check: Found unpatched CVE (CVE-2017-17522 CVE-2019-18348 CVE-2019-9674 CVE-2020-27619 CVE-2021-23336 CVE-2021-28861 CVE-2022-0391 CVE-2022-42919 CVE-2023-24329 CVE-2024-5642 CVE-2025-0938 CVE-2025-4516 CVE-2025-6069 CVE-2025-6075 CVE-2025-8194 CVE-2025-8291), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/python3/3.7.3-r0/temp/cve.log
WARNING: shadow-native-4.5-r0 do_cve_check: Found unpatched CVE (CVE-2007-5686 CVE-2013-4235 CVE-2024-56433), for more information check /home/deby/build/tmp/work/x86_64-linux/shadow-native/4.5-r0/temp/cve.log
WARNING: util-linux-2.33.1-r0 do_cve_check: Found unpatched CVE (CVE-2022-0563), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/util-linux/2.33.1-r0/temp/cve.log
WARNING: expat-native-2.2.6-r0 do_cve_check: Found unpatched CVE (CVE-2013-0340 CVE-2023-52426 CVE-2024-28757 CVE-2024-8176 CVE-2025-59375), for more information check /home/deby/build/tmp/work/x86_64-linux/expat-native/2.2.6-r0/temp/cve.log
WARNING: glib-2.0-2.58.3-r0 do_cve_check: Found unpatched CVE (CVE-2020-35457 CVE-2025-4373 CVE-2025-7039), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/glib-2.0/2.58.3-r0/temp/cve.log
WARNING: libpcre-native-8.39-r0 do_cve_check: Found unpatched CVE (CVE-2019-20838 CVE-2020-14155), for more information check /home/deby/build/tmp/work/x86_64-linux/libpcre-native/8.39-r0/temp/cve.log
WARNING: ed-native-1.15-r0 do_cve_check: Found unpatched CVE (CVE-2015-2987), for more information check /home/deby/build/tmp/work/x86_64-linux/ed-native/1.15-r0/temp/cve.log
WARNING: gcc-source-8.3.0-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /home/deby/build/tmp/work-shared/gcc-8.3.0-r0/temp/cve.log
WARNING: flex-native-2.6.4-r0 do_cve_check: Found unpatched CVE (CVE-2015-1773 CVE-2019-6293), for more information check /home/deby/build/tmp/work/x86_64-linux/flex-native/2.6.4-r0/temp/cve.log
WARNING: nss-native-3.42.1-r0 do_cve_check: Found unpatched CVE (CVE-2017-11695 CVE-2017-11696 CVE-2017-11697 CVE-2017-11698 CVE-2023-6135), for more information check /home/deby/build/tmp/work/x86_64-linux/nss-native/3.42.1-r0/temp/cve.log
WARNING: libarchive-native-3.3.3-r0 do_cve_check: Found unpatched CVE (CVE-2025-1632 CVE-2025-25724 CVE-2025-5914 CVE-2025-5916 CVE-2025-5917 CVE-2025-5918 CVE-2025-60753), for more information check /home/deby/build/tmp/work/x86_64-linux/libarchive-native/3.3.3-r0/temp/cve.log
WARNING: libxslt-native-1.1.32-r0 do_cve_check: Found unpatched CVE (CVE-2025-10911 CVE-2025-11731 CVE-2025-7425), for more information check /home/deby/build/tmp/work/x86_64-linux/libxslt-native/1.1.32-r0/temp/cve.log
WARNING: libgcc-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/libgcc/8.3.0-r0/temp/cve.log
WARNING: libxml2-native-2.9.4-r0 do_cve_check: Found unpatched CVE (CVE-2025-8732), for more information check /home/deby/build/tmp/work/x86_64-linux/libxml2-native/2.9.4-r0/temp/cve.log
WARNING: busybox-1.30.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000500 CVE-2021-42374 CVE-2021-42376 CVE-2023-39810 CVE-2024-58251 CVE-2025-46394 CVE-2025-60876), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/busybox/1.30.1-r0/temp/cve.log
WARNING: python3-setuptools-native-40.8.0-r0 do_cve_check: Found unpatched CVE (CVE-2022-40897 CVE-2024-6345 CVE-2025-47273), for more information check /home/deby/build/tmp/work/x86_64-linux/python3-setuptools-native/40.8.0-r0/temp/cve.log
WARNING: zlib-1.2.11-r0 do_cve_check: Found unpatched CVE (CVE-2023-45853), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/zlib/1.2.11-r0/temp/cve.log
WARNING: ncurses-6.1+20181013-r0 do_cve_check: Found unpatched CVE (CVE-2023-50495 CVE-2025-6141), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/ncurses/6.1+20181013-r0/temp/cve.log
WARNING: gcc-runtime-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/gcc-runtime/8.3.0-r0/temp/cve.log
WARNING: util-linux-native-2.33.1-r0 do_cve_check: Found unpatched CVE (CVE-2022-0563), for more information check /home/deby/build/tmp/work/x86_64-linux/util-linux-native/2.33.1-r0/temp/cve.log
WARNING: glib-2.0-native-2.58.3-r0 do_cve_check: Found unpatched CVE (CVE-2020-35457 CVE-2025-4373 CVE-2025-7039), for more information check /home/deby/build/tmp/work/x86_64-linux/glib-2.0-native/2.58.3-r0/temp/cve.log
WARNING: python3-native-3.7.3-r0 do_cve_check: Found unpatched CVE (CVE-2017-17522 CVE-2019-18348 CVE-2019-9674 CVE-2020-27619 CVE-2021-23336 CVE-2021-28861 CVE-2022-0391 CVE-2022-42919 CVE-2023-24329 CVE-2024-5642 CVE-2025-0938 CVE-2025-4516 CVE-2025-6069 CVE-2025-6075 CVE-2025-8194 CVE-2025-8291), for more information check /home/deby/build/tmp/work/x86_64-linux/python3-native/3.7.3-r0/temp/cve.log
WARNING: zlib-native-1.2.11-r0 do_cve_check: Found unpatched CVE (CVE-2023-45853), for more information check /home/deby/build/tmp/work/x86_64-linux/zlib-native/1.2.11-r0/temp/cve.log
WARNING: db-native-5.3.28-r0 do_cve_check: Found unpatched CVE (CVE-2019-8457), for more information check /home/deby/build/tmp/work/x86_64-linux/db-native/5.3.28-r0/temp/cve.log
WARNING: gcc-cross-aarch64-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /home/deby/build/tmp/work/x86_64-linux/gcc-cross-aarch64/8.3.0-r0/temp/cve.log
WARNING: binutils-native-2.31.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-17358 CVE-2018-17359 CVE-2018-17360 CVE-2018-20623 CVE-2018-20651 CVE-2018-20657 CVE-2018-20671 CVE-2018-20673 CVE-2018-20712 CVE-2019-1010180 CVE-2019-1010204 CVE-2020-19724 CVE-2020-21490 CVE-2020-35342 CVE-2020-35493 CVE-2020-35494 CVE-2020-35495 CVE-2020-35496 CVE-2020-35507 CVE-2021-20197 CVE-2021-3826 CVE-2021-45078 CVE-2021-46174 CVE-2021-46195 CVE-2022-38533 CVE-2022-44840 CVE-2022-45703 CVE-2022-47673 CVE-2022-47695 CVE-2022-47696 CVE-2022-48063 CVE-2022-48064 CVE-2022-48065 CVE-2023-25584 CVE-2024-53589 CVE-2024-57360 CVE-2025-0840 CVE-2025-5244 CVE-2025-5245), for more information check /home/deby/build/tmp/work/x86_64-linux/binutils-native/2.31.1-r0/temp/cve.log
WARNING: bison-native-3.3.2-r0 do_cve_check: Found unpatched CVE (CVE-2020-14150), for more information check /home/deby/build/tmp/work/x86_64-linux/bison-native/3.3.2-r0/temp/cve.log
WARNING: openssl-native-1.1.1n-r0 do_cve_check: Found unpatched CVE (CVE-2024-13176 CVE-2025-27587 CVE-2025-9230), for more information check /home/deby/build/tmp/work/x86_64-linux/openssl-native/1.1.1n-r0/temp/cve.log
WARNING: glibc-2.28-r0 do_cve_check: Found unpatched CVE (CVE-2010-4756 CVE-2018-20796 CVE-2019-1010022 CVE-2019-1010023 CVE-2019-1010024 CVE-2019-1010025 CVE-2019-9192 CVE-2020-1751 CVE-2023-0687 CVE-2023-4813 CVE-2025-8058), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/glibc/2.28-r0/temp/cve.log
WARNING: ncurses-native-6.1+20181013-r0 do_cve_check: Found unpatched CVE (CVE-2023-50495 CVE-2025-6141), for more information check /home/deby/build/tmp/work/x86_64-linux/ncurses-native/6.1+20181013-r0/temp/cve.log
WARNING: perl-native-5.28.1-r1 do_cve_check: Found unpatched CVE (CVE-2011-4116 CVE-2023-31486 CVE-2025-40909), for more information check /home/deby/build/tmp/work/x86_64-linux/perl-native/5.28.1-r1/temp/cve.log
WARNING: curl-native-7.64.0-r1 do_cve_check: Found unpatched CVE (CVE-2021-22922 CVE-2021-22923 CVE-2021-22926 CVE-2023-28320 CVE-2025-0725 CVE-2025-10966 CVE-2025-9086), for more information check /home/deby/build/tmp/work/x86_64-linux/curl-native/7.64.0-r1/temp/cve.log
WARNING: apt-native-1.2.24-r0 do_cve_check: Found unpatched CVE (CVE-2020-3810), for more information check /home/deby/build/tmp/work/x86_64-linux/apt-native/1.2.24-r0/temp/cve.log
WARNING: rpm-native-4.14.2.1-r0 do_cve_check: Found unpatched CVE (CVE-2021-20266 CVE-2021-3421 CVE-2021-3521 CVE-2021-35937 CVE-2021-35938 CVE-2021-35939), for more information check /home/deby/build/tmp/work/x86_64-linux/rpm-native/4.14.2.1-r0/temp/cve.log
WARNING: sqlite3-native-3_3.27.2-r0 do_cve_check: Found unpatched CVE (CVE-2019-19645 CVE-2020-11656 CVE-2020-13631 CVE-2022-35737 CVE-2025-52099 CVE-2025-6965), for more information check /home/deby/build/tmp/work/x86_64-linux/sqlite3-native/3_3.27.2-r0/temp/cve.log
WARNING: dpkg-native-1.19.8-r0 do_cve_check: Found unpatched CVE (CVE-2025-6297), for more information check /home/deby/build/tmp/work/x86_64-linux/dpkg-native/1.19.8-r0/temp/cve.log
WARNING: binutils-cross-aarch64-2.31.1-r0 do_cve_check: Found unpatched CVE (CVE-2018-17358 CVE-2018-17359 CVE-2018-17360 CVE-2018-20623 CVE-2018-20651 CVE-2018-20657 CVE-2018-20671 CVE-2018-20673 CVE-2018-20712 CVE-2019-1010180 CVE-2019-1010204 CVE-2020-19724 CVE-2020-21490 CVE-2020-35342 CVE-2020-35493 CVE-2020-35494 CVE-2020-35495 CVE-2020-35496 CVE-2020-35507 CVE-2021-20197 CVE-2021-3826 CVE-2021-45078 CVE-2021-46174 CVE-2021-46195 CVE-2022-38533 CVE-2022-44840 CVE-2022-45703 CVE-2022-47673 CVE-2022-47695 CVE-2022-47696 CVE-2022-48063 CVE-2022-48064 CVE-2022-48065 CVE-2023-25584 CVE-2024-53589 CVE-2024-57360 CVE-2025-0840 CVE-2025-5244 CVE-2025-5245), for more information check /home/deby/build/tmp/work/x86_64-linux/binutils-cross-aarch64/2.31.1-r0/temp/cve.log
WARNING: nasm-native-2.14-r0 do_cve_check: Found unpatched CVE (CVE-2018-1000886 CVE-2018-19213 CVE-2018-19755 CVE-2018-20535 CVE-2018-20538 CVE-2019-14248 CVE-2019-20334 CVE-2019-20352 CVE-2019-6290 CVE-2019-6291 CVE-2019-8343 CVE-2020-18780 CVE-2020-18974 CVE-2020-21528 CVE-2020-21685 CVE-2020-21686 CVE-2020-21687 CVE-2020-24241 CVE-2020-24242 CVE-2020-24978 CVE-2021-33450 CVE-2021-33452 CVE-2021-45256 CVE-2021-45257 CVE-2022-29654 CVE-2022-41420 CVE-2022-44368 CVE-2022-44369 CVE-2022-44370 CVE-2022-46456 CVE-2022-46457 CVE-2023-31722 CVE-2023-38665 CVE-2023-38667 CVE-2023-38668 CVE-2025-8842 CVE-2025-8843 CVE-2025-8844 CVE-2025-8845 CVE-2025-8846), for more information check /home/deby/build/tmp/work/x86_64-linux/nasm-native/2.14-r0/temp/cve.log
WARNING: libgcc-initial-8.3.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-15847 CVE-2023-4039), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/libgcc-initial/8.3.0-r0/temp/cve.log
WARNING: acpica-native-20181213-r0 do_cve_check: Found unpatched CVE (CVE-2024-24856), for more information check /home/deby/build/tmp/work/x86_64-linux/acpica-native/20181213-r0/temp/cve.log
WARNING: libpng-native-1.6.36-r0 do_cve_check: Found unpatched CVE (CVE-2019-6129 CVE-2025-64505 CVE-2025-64506 CVE-2025-64720 CVE-2025-65018), for more information check /home/deby/build/tmp/work/x86_64-linux/libpng-native/1.6.36-r0/temp/cve.log
WARNING: cross-localedef-native-2.28-r0 do_cve_check: Found unpatched CVE (CVE-2010-4756 CVE-2018-20796 CVE-2019-1010022 CVE-2019-1010023 CVE-2019-1010024 CVE-2019-1010025 CVE-2019-9192 CVE-2020-1751 CVE-2023-0687 CVE-2023-4813 CVE-2025-8058), for more information check /home/deby/build/tmp/work/x86_64-linux/cross-localedef-native/2.28-r0/temp/cve.log
WARNING: qemu-native-3.1-r0 do_cve_check: Found unpatched CVE (CVE-2007-0998 CVE-2018-20123 CVE-2018-20124 CVE-2018-20125 CVE-2018-20126 CVE-2018-20191 CVE-2018-20216 CVE-2019-12067 CVE-2019-12928 CVE-2019-12929 CVE-2019-20175 CVE-2019-8934 CVE-2020-25742 CVE-2020-25743 CVE-2020-35503 CVE-2021-20255 CVE-2021-3750 CVE-2022-36648 CVE-2022-3872 CVE-2022-4144 CVE-2023-1386 CVE-2023-1544 CVE-2024-3446 CVE-2024-4467 CVE-2024-6519 CVE-2024-7409 CVE-2024-7730 CVE-2024-8354 CVE-2024-8612 CVE-2025-11234), for more information check /home/deby/build/tmp/work/x86_64-linux/qemu-native/3.1-r0/temp/cve.log
WARNING: qemu-system-native-3.1-r0 do_cve_check: Found unpatched CVE (CVE-2007-0998 CVE-2018-20123 CVE-2018-20124 CVE-2018-20125 CVE-2018-20126 CVE-2018-20191 CVE-2018-20216 CVE-2019-12067 CVE-2019-12928 CVE-2019-12929 CVE-2019-20175 CVE-2019-8934 CVE-2020-25742 CVE-2020-25743 CVE-2020-35503 CVE-2021-20255 CVE-2021-3750 CVE-2022-36648 CVE-2022-3872 CVE-2022-4144 CVE-2023-1386 CVE-2023-1544 CVE-2024-3446 CVE-2024-4467 CVE-2024-6519 CVE-2024-7409 CVE-2024-7730 CVE-2024-8354 CVE-2024-8612 CVE-2025-11234), for more information check /home/deby/build/tmp/work/x86_64-linux/qemu-system-native/3.1-r0/temp/cve.log
WARNING: linux-base-4.19+gitAUTOINC+f67c504655-r0 do_cve_check: Found unpatched CVE (CVE-1999-0524 CVE-1999-0656 CVE-2006-2932 CVE-2007-2764 CVE-2007-4998 CVE-2008-2544 CVE-2008-4609 CVE-2010-4563 CVE-2010-5321 CVE-2015-2877 CVE-2015-7312 CVE-2016-3699 CVE-2017-1000377 CVE-2017-6264 CVE-2018-1121 CVE-2019-0149 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-14899 CVE-2019-16089 CVE-2019-19083 CVE-2019-20794 CVE-2020-0347 CVE-2020-11725 CVE-2020-12362 CVE-2020-12363 CVE-2020-12364 CVE-2020-15802 CVE-2020-16120 CVE-2020-26140 CVE-2020-26141 CVE-2020-26142 CVE-2020-26143 CVE-2020-26144 CVE-2020-26145 CVE-2020-26146 CVE-2020-26541 CVE-2020-26556 CVE-2020-26557 CVE-2020-26559 CVE-2020-26560 CVE-2020-27820 CVE-2020-27835 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2020-36691 CVE-2020-36766 CVE-2020-36780 CVE-2020-36782 CVE-2020-36783 CVE-2020-36784 CVE-2021-0399 CVE-2021-0929 CVE-2021-0961 CVE-2021-1076 CVE-2021-1077 CVE-2021-26934 CVE-2021-29256 CVE-2021-31615 CVE-2021-32078 CVE-2021-33061 CVE-2021-33096 CVE-2021-3492 CVE-2021-3669 CVE-2021-3714 CVE-2021-3773 CVE-2021-3847 CVE-2021-3864 CVE-2021-3923 CVE-2021-39800 CVE-2021-39801 CVE-2021-39802 CVE-2021-4037 CVE-2021-4460 CVE-2021-46925 CVE-2021-46928 CVE-2021-46941 CVE-2021-46984 CVE-2021-47049 CVE-2021-47063 CVE-2021-47074 CVE-2021-47076 CVE-2021-47077 CVE-2021-47083 CVE-2021-47101 CVE-2021-47110 CVE-2021-47112 CVE-2021-47113 CVE-2021-47119 CVE-2021-47131 CVE-2021-47143 CVE-2021-47163 CVE-2021-47167 CVE-2021-47182 CVE-2021-47188 CVE-2021-47191 CVE-2021-47201 CVE-2021-47202 CVE-2021-47204 CVE-2021-47205 CVE-2021-47219 CVE-2021-47224 CVE-2021-47234 CVE-2021-47246 CVE-2021-47265 CVE-2021-47275 CVE-2021-47281 CVE-2021-47283 CVE-2021-47307 CVE-2021-47325 CVE-2021-47329 CVE-2021-47335 CVE-2021-47350 CVE-2021-47351 CVE-2021-47354 CVE-2021-47366 CVE-2021-47378 CVE-2021-47379 CVE-2021-47384 CVE-2021-47385 CVE-2021-47386 CVE-2021-47391 CVE-2021-47396 CVE-2021-47407 CVE-2021-47408 CVE-2021-47410 CVE-2021-47412 CVE-2021-47414 CVE-2021-47431 CVE-2021-47433 CVE-2021-47438 CVE-2021-47441 CVE-2021-47455 CVE-2021-47466 CVE-2021-47473 CVE-2021-47479 CVE-2021-47490 CVE-2021-47493 CVE-2021-47496 CVE-2021-47498 CVE-2021-47501 CVE-2021-47508 CVE-2021-47523 CVE-2021-47544 CVE-2021-47551 CVE-2021-47552 CVE-2021-47559 CVE-2021-47577 CVE-2021-47580 CVE-2021-47582 CVE-2021-47597 CVE-2021-47599 CVE-2021-47618 CVE-2021-47622 CVE-2021-47623 CVE-2021-47632 CVE-2021-47635 CVE-2021-47644 CVE-2021-47648 CVE-2021-47653 CVE-2022-0168 CVE-2022-0400 CVE-2022-0480 CVE-2022-1015 CVE-2022-1247 CVE-2022-20158 CVE-2022-21499 CVE-2022-2327 CVE-2022-23825 CVE-2022-25265 CVE-2022-25836 CVE-2022-25837 CVE-2022-26047 CVE-2022-27672 CVE-2022-28667 CVE-2022-29582 CVE-2022-2961 CVE-2022-3108 CVE-2022-3303 CVE-2022-3344 CVE-2022-3523 CVE-2022-36397 CVE-2022-36402 CVE-2022-39189 CVE-2022-4129 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-4543 CVE-2022-45885 CVE-2022-47520 CVE-2022-48628 CVE-2022-48631 CVE-2022-48633 CVE-2022-48664 CVE-2022-48673 CVE-2022-48674 CVE-2022-48712 CVE-2022-48731 CVE-2022-48733 CVE-2022-48734 CVE-2022-48744 CVE-2022-48751 CVE-2022-48755 CVE-2022-48763 CVE-2022-48765 CVE-2022-48766 CVE-2022-48789 CVE-2022-48791 CVE-2022-48792 CVE-2022-48802 CVE-2022-48806 CVE-2022-48811 CVE-2022-48825 CVE-2022-48826 CVE-2022-48827 CVE-2022-48852 CVE-2022-48863 CVE-2022-48865 CVE-2022-48875 CVE-2022-48901 CVE-2022-48920 CVE-2022-48943 CVE-2022-48950 CVE-2022-48953 CVE-2022-48961 CVE-2022-48975 CVE-2022-48986 CVE-2022-49006 CVE-2022-49013 CVE-2022-49019 CVE-2022-49026 CVE-2022-49027 CVE-2022-49028 CVE-2022-49046 CVE-2022-49054 CVE-2022-49065 CVE-2022-49067 CVE-2022-49072 CVE-2022-49097 CVE-2022-49106 CVE-2022-49107 CVE-2022-49110 CVE-2022-49117 CVE-2022-49118 CVE-2022-49120 CVE-2022-49121 CVE-2022-49124 CVE-2022-49128 CVE-2022-49134 CVE-2022-49135 CVE-2022-49138 CVE-2022-49139 CVE-2022-49149 CVE-2022-49154 CVE-2022-49156 CVE-2022-49157 CVE-2022-49158 CVE-2022-49164 CVE-2022-49168 CVE-2022-49169 CVE-2022-49170 CVE-2022-49172 CVE-2022-49174 CVE-2022-49178 CVE-2022-49179 CVE-2022-49180 CVE-2022-49188 CVE-2022-49189 CVE-2022-49190 CVE-2022-49194 CVE-2022-49196 CVE-2022-49220 CVE-2022-49226 CVE-2022-49241 CVE-2022-49255 CVE-2022-49258 CVE-2022-49267 CVE-2022-49281 CVE-2022-49285 CVE-2022-49286 CVE-2022-49289 CVE-2022-49296 CVE-2022-49301 CVE-2022-49303 CVE-2022-49309 CVE-2022-49311 CVE-2022-49312 CVE-2022-49317 CVE-2022-49318 CVE-2022-49319 CVE-2022-49320 CVE-2022-49323 CVE-2022-49325 CVE-2022-49327 CVE-2022-49328 CVE-2022-49336 CVE-2022-49342 CVE-2022-49360 CVE-2022-49361 CVE-2022-49363 CVE-2022-49364 CVE-2022-49371 CVE-2022-49373 CVE-2022-49376 CVE-2022-49380 CVE-2022-49385 CVE-2022-49390 CVE-2022-49398 CVE-2022-49409 CVE-2022-49411 CVE-2022-49413 CVE-2022-49414 CVE-2022-49420 CVE-2022-49428 CVE-2022-49431 CVE-2022-49437 CVE-2022-49440 CVE-2022-49443 CVE-2022-49445 CVE-2022-49462 CVE-2022-49465 CVE-2022-49468 CVE-2022-49486 CVE-2022-49497 CVE-2022-49504 CVE-2022-49512 CVE-2022-49513 CVE-2022-49519 CVE-2022-49520 CVE-2022-49521 CVE-2022-49522 CVE-2022-49523 CVE-2022-49528 CVE-2022-49531 CVE-2022-49534 CVE-2022-49535 CVE-2022-49536 CVE-2022-49542 CVE-2022-49545 CVE-2022-49546 CVE-2022-49555 CVE-2022-49563 CVE-2022-49564 CVE-2022-49566 CVE-2022-49568 CVE-2022-49577 CVE-2022-49578 CVE-2022-49579 CVE-2022-49580 CVE-2022-49584 CVE-2022-49585 CVE-2022-49596 CVE-2022-49597 CVE-2022-49599 CVE-2022-49603 CVE-2022-49610 CVE-2022-49622 CVE-2022-49623 CVE-2022-49630 CVE-2022-49632 CVE-2022-49635 CVE-2022-49640 CVE-2022-49641 CVE-2022-49644 CVE-2022-49650 CVE-2022-49651 CVE-2022-49658 CVE-2022-49668 CVE-2022-49693 CVE-2022-49698 CVE-2022-49710 CVE-2022-49711 CVE-2022-49720 CVE-2022-49728 CVE-2022-49730 CVE-2022-49733 CVE-2022-49740 CVE-2022-49741 CVE-2022-49742 CVE-2022-49749 CVE-2022-49758 CVE-2022-49764 CVE-2022-49765 CVE-2022-49766 CVE-2022-49789 CVE-2022-49799 CVE-2022-49813 CVE-2022-49823 CVE-2022-49824 CVE-2022-49825 CVE-2022-49828 CVE-2022-49829 CVE-2022-49831 CVE-2022-49838 CVE-2022-49839 CVE-2022-49879 CVE-2022-49892 CVE-2022-49898 CVE-2022-49913 CVE-2022-49923 CVE-2022-49924 CVE-2022-49925 CVE-2022-49932 CVE-2022-49937 CVE-2022-49938 CVE-2022-49954 CVE-2022-49967 CVE-2022-49975 CVE-2022-49979 CVE-2022-49980 CVE-2022-49989 CVE-2022-49998 CVE-2022-50009 CVE-2022-50011 CVE-2022-50021 CVE-2022-50023 CVE-2022-50024 CVE-2022-50030 CVE-2022-50036 CVE-2022-50047 CVE-2022-50053 CVE-2022-50055 CVE-2022-50062 CVE-2022-50065 CVE-2022-50066 CVE-2022-50073 CVE-2022-50082 CVE-2022-50086 CVE-2022-50092 CVE-2022-50093 CVE-2022-50098 CVE-2022-50103 CVE-2022-50108 CVE-2022-50114 CVE-2022-50116 CVE-2022-50120 CVE-2022-50129 CVE-2022-50138 CVE-2022-50144 CVE-2022-50146 CVE-2022-50159 CVE-2022-50163 CVE-2022-50166 CVE-2022-50174 CVE-2022-50175 CVE-2022-50181 CVE-2022-50204 CVE-2022-50226 CVE-2022-50236 CVE-2022-50241 CVE-2022-50246 CVE-2022-50256 CVE-2022-50260 CVE-2022-50266 CVE-2022-50267 CVE-2022-50293 CVE-2022-50300 CVE-2022-50303 CVE-2022-50304 CVE-2022-50313 CVE-2022-50316 CVE-2022-50335 CVE-2022-50340 CVE-2022-50341 CVE-2022-50350 CVE-2022-50356 CVE-2022-50358 CVE-2022-50364 CVE-2022-50373 CVE-2022-50374 CVE-2022-50375 CVE-2022-50376 CVE-2022-50385 CVE-2022-50395 CVE-2022-50396 CVE-2022-50399 CVE-2022-50406 CVE-2022-50410 CVE-2022-50412 CVE-2022-50422 CVE-2022-50439 CVE-2022-50443 CVE-2022-50445 CVE-2022-50453 CVE-2022-50456 CVE-2022-50467 CVE-2022-50469 CVE-2022-50471 CVE-2022-50485 CVE-2022-50492 CVE-2022-50500 CVE-2022-50511 CVE-2022-50513 CVE-2022-50516 CVE-2022-50518 CVE-2022-50527 CVE-2022-50532 CVE-2022-50539 CVE-2022-50549 CVE-2022-50550 CVE-2022-50552 CVE-2022-50554 CVE-2022-50556 CVE-2022-50560 CVE-2022-50562 CVE-2022-50571 CVE-2022-50574 CVE-2022-50580 CVE-2023-1076 CVE-2023-1249 CVE-2023-1476 CVE-2023-1582 CVE-2023-1611 CVE-2023-20569 CVE-2023-20588 CVE-2023-20928 CVE-2023-20938 CVE-2023-20941 CVE-2023-2124 CVE-2023-2177 CVE-2023-23000 CVE-2023-23039 CVE-2023-24023 CVE-2023-26242 CVE-2023-28466 CVE-2023-28746 CVE-2023-3079 CVE-2023-32256 CVE-2023-33288 CVE-2023-3397 CVE-2023-3640 CVE-2023-37453 CVE-2023-37454 CVE-2023-3863 CVE-2023-39176 CVE-2023-39179 CVE-2023-39180 CVE-2023-39197 CVE-2023-39198 CVE-2023-4010 CVE-2023-4133 CVE-2023-4134 CVE-2023-51779 CVE-2023-52458 CVE-2023-52474 CVE-2023-52476 CVE-2023-52479 CVE-2023-52481 CVE-2023-52485 CVE-2023-52488 CVE-2023-52491 CVE-2023-52500 CVE-2023-52506 CVE-2023-52508 CVE-2023-52511 CVE-2023-52515 CVE-2023-52522 CVE-2023-52530 CVE-2023-52531 CVE-2023-52569 CVE-2023-52572 CVE-2023-52586 CVE-2023-52588 CVE-2023-52589 CVE-2023-52590 CVE-2023-52591 CVE-2023-52595 CVE-2023-52614 CVE-2023-52617 CVE-2023-52624 CVE-2023-52629 CVE-2023-52638 CVE-2023-52639 CVE-2023-52640 CVE-2023-52642 CVE-2023-52652 CVE-2023-52653 CVE-2023-52656 CVE-2023-52664 CVE-2023-52669 CVE-2023-52671 CVE-2023-52700 CVE-2023-52708 CVE-2023-52732 CVE-2023-52735 CVE-2023-52736 CVE-2023-52737 CVE-2023-52741 CVE-2023-52743 CVE-2023-52745 CVE-2023-52751 CVE-2023-52752 CVE-2023-52754 CVE-2023-52757 CVE-2023-52760 CVE-2023-52781 CVE-2023-52784 CVE-2023-52811 CVE-2023-52821 CVE-2023-52828 CVE-2023-52834 CVE-2023-52854 CVE-2023-52871 CVE-2023-52878 CVE-2023-52882 CVE-2023-52888 CVE-2023-52903 CVE-2023-52920 CVE-2023-52925 CVE-2023-52975 CVE-2023-52996 CVE-2023-53000 CVE-2023-53008 CVE-2023-53010 CVE-2023-53020 CVE-2023-53031 CVE-2023-53039 CVE-2023-53041 CVE-2023-53042 CVE-2023-53068 CVE-2023-53079 CVE-2023-53080 CVE-2023-53091 CVE-2023-53093 CVE-2023-53094 CVE-2023-53097 CVE-2023-53098 CVE-2023-53103 CVE-2023-53111 CVE-2023-53118 CVE-2023-53131 CVE-2023-53135 CVE-2023-53149 CVE-2023-53171 CVE-2023-53178 CVE-2023-53200 CVE-2023-53201 CVE-2023-53217 CVE-2023-53218 CVE-2023-53225 CVE-2023-53230 CVE-2023-53241 CVE-2023-53244 CVE-2023-53247 CVE-2023-53248 CVE-2023-53250 CVE-2023-53254 CVE-2023-53258 CVE-2023-53270 CVE-2023-53280 CVE-2023-53282 CVE-2023-53286 CVE-2023-53287 CVE-2023-53292 CVE-2023-53315 CVE-2023-53321 CVE-2023-53326 CVE-2023-53328 CVE-2023-53332 CVE-2023-53333 CVE-2023-53335 CVE-2023-53338 CVE-2023-53346 CVE-2023-53348 CVE-2023-53358 CVE-2023-53368 CVE-2023-53369 CVE-2023-53370 CVE-2023-53383 CVE-2023-53387 CVE-2023-53391 CVE-2023-53393 CVE-2023-53397 CVE-2023-53419 CVE-2023-53429 CVE-2023-53432 CVE-2023-53433 CVE-2023-53438 CVE-2023-53441 CVE-2023-53443 CVE-2023-53446 CVE-2023-53447 CVE-2023-53458 CVE-2023-53468 CVE-2023-53469 CVE-2023-53476 CVE-2023-53477 CVE-2023-53482 CVE-2023-53491 CVE-2023-53499 CVE-2023-53503 CVE-2023-53505 CVE-2023-53509 CVE-2023-53510 CVE-2023-53512 CVE-2023-53513 CVE-2023-53517 CVE-2023-53520 CVE-2023-53530 CVE-2023-53538 CVE-2023-53539 CVE-2023-53540 CVE-2023-53544 CVE-2023-53545 CVE-2023-53556 CVE-2023-53562 CVE-2023-53576 CVE-2023-53577 CVE-2023-53579 CVE-2023-53584 CVE-2023-53586 CVE-2023-53588 CVE-2023-53589 CVE-2023-53594 CVE-2023-53596 CVE-2023-53606 CVE-2023-53607 CVE-2023-53612 CVE-2023-53615 CVE-2023-53618 CVE-2023-53620 CVE-2023-53624 CVE-2023-53625 CVE-2023-53627 CVE-2023-53635 CVE-2023-53647 CVE-2023-53651 CVE-2023-53661 CVE-2023-53671 CVE-2023-53679 CVE-2023-53680 CVE-2023-53682 CVE-2023-53684 CVE-2023-53685 CVE-2023-53692 CVE-2023-53696 CVE-2023-53707 CVE-2023-53708 CVE-2023-53712 CVE-2023-53718 CVE-2023-53733 CVE-2023-6121 CVE-2023-6240 CVE-2023-6535 CVE-2023-6610 CVE-2024-0193 CVE-2024-1151 CVE-2024-21803 CVE-2024-21823 CVE-2024-2193 CVE-2024-2201 CVE-2024-23307 CVE-2024-25740 CVE-2024-25743 CVE-2024-26584 CVE-2024-26586 CVE-2024-26595 CVE-2024-26614 CVE-2024-26622 CVE-2024-26640 CVE-2024-26641 CVE-2024-26647 CVE-2024-26648 CVE-2024-26656 CVE-2024-26659 CVE-2024-26668 CVE-2024-26677 CVE-2024-26686 CVE-2024-26687 CVE-2024-26691 CVE-2024-26700 CVE-2024-26706 CVE-2024-26715 CVE-2024-26719 CVE-2024-26726 CVE-2024-26733 CVE-2024-26736 CVE-2024-26739 CVE-2024-26740 CVE-2024-26743 CVE-2024-26747 CVE-2024-26756 CVE-2024-26757 CVE-2024-26758 CVE-2024-26759 CVE-2024-26765 CVE-2024-26767 CVE-2024-26769 CVE-2024-26771 CVE-2024-26775 CVE-2024-26804 CVE-2024-26810 CVE-2024-26811 CVE-2024-26812 CVE-2024-26813 CVE-2024-26828 CVE-2024-26830 CVE-2024-26841 CVE-2024-26843 CVE-2024-26844 CVE-2024-26846 CVE-2024-26865 CVE-2024-26866 CVE-2024-26869 CVE-2024-26872 CVE-2024-26876 CVE-2024-26882 CVE-2024-26902 CVE-2024-26907 CVE-2024-26910 CVE-2024-26915 CVE-2024-26921 CVE-2024-26925 CVE-2024-26960 CVE-2024-26961 CVE-2024-26996 CVE-2024-27004 CVE-2024-27010 CVE-2024-27011 CVE-2024-27019 CVE-2024-27025 CVE-2024-27032 CVE-2024-27037 CVE-2024-27051 CVE-2024-27054 CVE-2024-27056 CVE-2024-27072 CVE-2024-27073 CVE-2024-27297 CVE-2024-27402 CVE-2024-27403 CVE-2024-27415 CVE-2024-27437 CVE-2024-28956 CVE-2024-35247 CVE-2024-35784 CVE-2024-35790 CVE-2024-35791 CVE-2024-35794 CVE-2024-35799 CVE-2024-35803 CVE-2024-35805 CVE-2024-35808 CVE-2024-35826 CVE-2024-35837 CVE-2024-35839 CVE-2024-35843 CVE-2024-35863 CVE-2024-35864 CVE-2024-35865 CVE-2024-35866 CVE-2024-35867 CVE-2024-35868 CVE-2024-35870 CVE-2024-35871 CVE-2024-35875 CVE-2024-35878 CVE-2024-35887 CVE-2024-35896 CVE-2024-35904 CVE-2024-35931 CVE-2024-35932 CVE-2024-35939 CVE-2024-35945 CVE-2024-35950 CVE-2024-35965 CVE-2024-35966 CVE-2024-35967 CVE-2024-35995 CVE-2024-35998 CVE-2024-36009 CVE-2024-36013 CVE-2024-36029 CVE-2024-36270 CVE-2024-36331 CVE-2024-36347 CVE-2024-36350 CVE-2024-36357 CVE-2024-36479 CVE-2024-36880 CVE-2024-36901 CVE-2024-36903 CVE-2024-36910 CVE-2024-36911 CVE-2024-36914 CVE-2024-36917 CVE-2024-36923 CVE-2024-36924 CVE-2024-36927 CVE-2024-36939 CVE-2024-36952 CVE-2024-36953 CVE-2024-36968 CVE-2024-37021 CVE-2024-37354 CVE-2024-38544 CVE-2024-38545 CVE-2024-38546 CVE-2024-38547 CVE-2024-38553 CVE-2024-38570 CVE-2024-38580 CVE-2024-38588 CVE-2024-38597 CVE-2024-38600 CVE-2024-38608 CVE-2024-38611 CVE-2024-38630 CVE-2024-39467 CVE-2024-39490 CVE-2024-39494 CVE-2024-39495 CVE-2024-40905 CVE-2024-40911 CVE-2024-40918 CVE-2024-40927 CVE-2024-40929 CVE-2024-40961 CVE-2024-40965 CVE-2024-40966 CVE-2024-40967 CVE-2024-40971 CVE-2024-40972 CVE-2024-40977 CVE-2024-40980 CVE-2024-40990 CVE-2024-40995 CVE-2024-40998 CVE-2024-40999 CVE-2024-41005 CVE-2024-41008 CVE-2024-41013 CVE-2024-41014 CVE-2024-41023 CVE-2024-41060 CVE-2024-41062 CVE-2024-41064 CVE-2024-41065 CVE-2024-41066 CVE-2024-41067 CVE-2024-41069 CVE-2024-41070 CVE-2024-41073 CVE-2024-41077 CVE-2024-41078 CVE-2024-41079 CVE-2024-41082 CVE-2024-41935 CVE-2024-42067 CVE-2024-42068 CVE-2024-42077 CVE-2024-42080 CVE-2024-42082 CVE-2024-42098 CVE-2024-42110 CVE-2024-42114 CVE-2024-42120 CVE-2024-42122 CVE-2024-42124 CVE-2024-42129 CVE-2024-42135 CVE-2024-42155 CVE-2024-42156 CVE-2024-42160 CVE-2024-42225 CVE-2024-42244 CVE-2024-42252 CVE-2024-42253 CVE-2024-42267 CVE-2024-42281 CVE-2024-42306 CVE-2024-42312 CVE-2024-42319 CVE-2024-42322 CVE-2024-43819 CVE-2024-43831 CVE-2024-43863 CVE-2024-43866 CVE-2024-43867 CVE-2024-43872 CVE-2024-43892 CVE-2024-43900 CVE-2024-43902 CVE-2024-43905 CVE-2024-43907 CVE-2024-43909 CVE-2024-43911 CVE-2024-43912 CVE-2024-44938 CVE-2024-44939 CVE-2024-44940 CVE-2024-44942 CVE-2024-44949 CVE-2024-44950 CVE-2024-44958 CVE-2024-44963 CVE-2024-44982 CVE-2024-44995 CVE-2024-45003 CVE-2024-45015 CVE-2024-46676 CVE-2024-46679 CVE-2024-46681 CVE-2024-46689 CVE-2024-46695 CVE-2024-46702 CVE-2024-46705 CVE-2024-46707 CVE-2024-46713 CVE-2024-46714 CVE-2024-46715 CVE-2024-46716 CVE-2024-46720 CVE-2024-46724 CVE-2024-46731 CVE-2024-46733 CVE-2024-46742 CVE-2024-46751 CVE-2024-46752 CVE-2024-46753 CVE-2024-46754 CVE-2024-46762 CVE-2024-46763 CVE-2024-46770 CVE-2024-46774 CVE-2024-46775 CVE-2024-46783 CVE-2024-46787 CVE-2024-46802 CVE-2024-46803 CVE-2024-46804 CVE-2024-46809 CVE-2024-46818 CVE-2024-46821 CVE-2024-46822 CVE-2024-46823 CVE-2024-46826 CVE-2024-46832 CVE-2024-46834 CVE-2024-46841 CVE-2024-46848 CVE-2024-46849 CVE-2024-46859 CVE-2024-46861 CVE-2024-47141 CVE-2024-47143 CVE-2024-47660 CVE-2024-47666 CVE-2024-47667 CVE-2024-47668 CVE-2024-47673 CVE-2024-47674 CVE-2024-47678 CVE-2024-47683 CVE-2024-47690 CVE-2024-47691 CVE-2024-47726 CVE-2024-47735 CVE-2024-47745 CVE-2024-47809 CVE-2024-48875 CVE-2024-49571 CVE-2024-49851 CVE-2024-49858 CVE-2024-49859 CVE-2024-49868 CVE-2024-49875 CVE-2024-49879 CVE-2024-49888 CVE-2024-49889 CVE-2024-49890 CVE-2024-49891 CVE-2024-49899 CVE-2024-49901 CVE-2024-49906 CVE-2024-49914 CVE-2024-49920 CVE-2024-49921 CVE-2024-49922 CVE-2024-49923 CVE-2024-49925 CVE-2024-49926 CVE-2024-49927 CVE-2024-49928 CVE-2024-49929 CVE-2024-49930 CVE-2024-49931 CVE-2024-49932 CVE-2024-49939 CVE-2024-49940 CVE-2024-49945 CVE-2024-49950 CVE-2024-49988 CVE-2024-49989 CVE-2024-49991 CVE-2024-49992 CVE-2024-49994 CVE-2024-50003 CVE-2024-50010 CVE-2024-50015 CVE-2024-50017 CVE-2024-50033 CVE-2024-50036 CVE-2024-50038 CVE-2024-50039 CVE-2024-50048 CVE-2024-50058 CVE-2024-50059 CVE-2024-50062 CVE-2024-50067 CVE-2024-50073 CVE-2024-50082 CVE-2024-50086 CVE-2024-50095 CVE-2024-50112 CVE-2024-50115 CVE-2024-50134 CVE-2024-50135 CVE-2024-50166 CVE-2024-50183 CVE-2024-50187 CVE-2024-50199 CVE-2024-50211 CVE-2024-50217 CVE-2024-50233 CVE-2024-50242 CVE-2024-50244 CVE-2024-50246 CVE-2024-50256 CVE-2024-50258 CVE-2024-50272 CVE-2024-50280 CVE-2024-50285 CVE-2024-50286 CVE-2024-50289 CVE-2024-50304 CVE-2024-52559 CVE-2024-53058 CVE-2024-53088 CVE-2024-53089 CVE-2024-53090 CVE-2024-53093 CVE-2024-53095 CVE-2024-53128 CVE-2024-53144 CVE-2024-53145 CVE-2024-53148 CVE-2024-53168 CVE-2024-53174 CVE-2024-53177 CVE-2024-53179 CVE-2024-53187 CVE-2024-53190 CVE-2024-53195 CVE-2024-53210 CVE-2024-53218 CVE-2024-53224 CVE-2024-53241 CVE-2024-53685 CVE-2024-54458 CVE-2024-54683 CVE-2024-56369 CVE-2024-56533 CVE-2024-56551 CVE-2024-56558 CVE-2024-56565 CVE-2024-56566 CVE-2024-56568 CVE-2024-56583 CVE-2024-56586 CVE-2024-56588 CVE-2024-56589 CVE-2024-56590 CVE-2024-56591 CVE-2024-56592 CVE-2024-56594 CVE-2024-56599 CVE-2024-56611 CVE-2024-56614 CVE-2024-56615 CVE-2024-56616 CVE-2024-56623 CVE-2024-56640 CVE-2024-56641 CVE-2024-56642 CVE-2024-56647 CVE-2024-56651 CVE-2024-56658 CVE-2024-56662 CVE-2024-56688 CVE-2024-56692 CVE-2024-56698 CVE-2024-56703 CVE-2024-56705 CVE-2024-56722 CVE-2024-56756 CVE-2024-56759 CVE-2024-56763 CVE-2024-56776 CVE-2024-56777 CVE-2024-56778 CVE-2024-56785 CVE-2024-56787 CVE-2024-57795 CVE-2024-57809 CVE-2024-57834 CVE-2024-57838 CVE-2024-57872 CVE-2024-57883 CVE-2024-57887 CVE-2024-57888 CVE-2024-57890 CVE-2024-57893 CVE-2024-57896 CVE-2024-57897 CVE-2024-57898 CVE-2024-57899 CVE-2024-57903 CVE-2024-57924 CVE-2024-57939 CVE-2024-57951 CVE-2024-57974 CVE-2024-57975 CVE-2024-57976 CVE-2024-57977 CVE-2024-57982 CVE-2024-58005 CVE-2024-58012 CVE-2024-58053 CVE-2024-58072 CVE-2024-58085 CVE-2024-58094 CVE-2024-58095 CVE-2024-58241 CVE-2024-8805 CVE-2025-21629 CVE-2025-21634 CVE-2025-21635 CVE-2025-21648 CVE-2025-21653 CVE-2025-21682 CVE-2025-21690 CVE-2025-21697 CVE-2025-21708 CVE-2025-21711 CVE-2025-21712 CVE-2025-21731 CVE-2025-21738 CVE-2025-21750 CVE-2025-21758 CVE-2025-21759 CVE-2025-21768 CVE-2025-21792 CVE-2025-21796 CVE-2025-21801 CVE-2025-21802 CVE-2025-21806 CVE-2025-21812 CVE-2025-21816 CVE-2025-21820 CVE-2025-21821 CVE-2025-21831 CVE-2025-21838 CVE-2025-21855 CVE-2025-21862 CVE-2025-21881 CVE-2025-21891 CVE-2025-21899 CVE-2025-21931 CVE-2025-21941 CVE-2025-21957 CVE-2025-21969 CVE-2025-21976 CVE-2025-21985 CVE-2025-21999 CVE-2025-22008 CVE-2025-22022 CVE-2025-22025 CVE-2025-22026 CVE-2025-22027 CVE-2025-22028 CVE-2025-22037 CVE-2025-22038 CVE-2025-22040 CVE-2025-22041 CVE-2025-22042 CVE-2025-22053 CVE-2025-22055 CVE-2025-22057 CVE-2025-22060 CVE-2025-22072 CVE-2025-22083 CVE-2025-22090 CVE-2025-22104 CVE-2025-22109 CVE-2025-22121 CVE-2025-22125 CVE-2025-23131 CVE-2025-23141 CVE-2025-23156 CVE-2025-23161 CVE-2025-27558 CVE-2025-37739 CVE-2025-37742 CVE-2025-37756 CVE-2025-37765 CVE-2025-37775 CVE-2025-37778 CVE-2025-37800 CVE-2025-37805 CVE-2025-37807 CVE-2025-37808 CVE-2025-37819 CVE-2025-37830 CVE-2025-37833 CVE-2025-37834 CVE-2025-37836 CVE-2025-37850 CVE-2025-37852 CVE-2025-37853 CVE-2025-37856 CVE-2025-37877 CVE-2025-37878 CVE-2025-37879 CVE-2025-37880 CVE-2025-37882 CVE-2025-37883 CVE-2025-37885 CVE-2025-37909 CVE-2025-37911 CVE-2025-37925 CVE-2025-37928 CVE-2025-37942 CVE-2025-37947 CVE-2025-37948 CVE-2025-37951 CVE-2025-37954 CVE-2025-37961 CVE-2025-37963 CVE-2025-37980 CVE-2025-37991 CVE-2025-37992 CVE-2025-38039 CVE-2025-38040 CVE-2025-38041 CVE-2025-38043 CVE-2025-38045 CVE-2025-38048 CVE-2025-38063 CVE-2025-38064 CVE-2025-38065 CVE-2025-38067 CVE-2025-38068 CVE-2025-38069 CVE-2025-38071 CVE-2025-38072 CVE-2025-38073 CVE-2025-38074 CVE-2025-38084 CVE-2025-38085 CVE-2025-38094 CVE-2025-38099 CVE-2025-38105 CVE-2025-38112 CVE-2025-38117 CVE-2025-38119 CVE-2025-38126 CVE-2025-38129 CVE-2025-38136 CVE-2025-38161 CVE-2025-38192 CVE-2025-38207 CVE-2025-38214 CVE-2025-38215 CVE-2025-38218 CVE-2025-38229 CVE-2025-38232 CVE-2025-38234 CVE-2025-38250 CVE-2025-38261 CVE-2025-38262 CVE-2025-38269 CVE-2025-38272 CVE-2025-38280 CVE-2025-38310 CVE-2025-38319 CVE-2025-38331 CVE-2025-38333 CVE-2025-38359 CVE-2025-38361 CVE-2025-38371 CVE-2025-38384 CVE-2025-38409 CVE-2025-38410 CVE-2025-38425 CVE-2025-38449 CVE-2025-38467 CVE-2025-38478 CVE-2025-38481 CVE-2025-38499 CVE-2025-38503 CVE-2025-38512 CVE-2025-38516 CVE-2025-38524 CVE-2025-38527 CVE-2025-38531 CVE-2025-38544 CVE-2025-38556 CVE-2025-38560 CVE-2025-38576 CVE-2025-38584 CVE-2025-38591 CVE-2025-38595 CVE-2025-38614 CVE-2025-38623 CVE-2025-38624 CVE-2025-38626 CVE-2025-38643 CVE-2025-38644 CVE-2025-38656 CVE-2025-38665 CVE-2025-38668 CVE-2025-38679 CVE-2025-38683 CVE-2025-38685 CVE-2025-38687 CVE-2025-38695 CVE-2025-38702 CVE-2025-38705 CVE-2025-38706 CVE-2025-38709 CVE-2025-38710 CVE-2025-38716 CVE-2025-38717 CVE-2025-38728 CVE-2025-38734 CVE-2025-39677 CVE-2025-39683 CVE-2025-39684 CVE-2025-39685 CVE-2025-39686 CVE-2025-39697 CVE-2025-39702 CVE-2025-39705 CVE-2025-39706 CVE-2025-39715 CVE-2025-39716 CVE-2025-39726 CVE-2025-39737 CVE-2025-39738 CVE-2025-39744 CVE-2025-39745 CVE-2025-39746 CVE-2025-39748 CVE-2025-39752 CVE-2025-39754 CVE-2025-39759 CVE-2025-39760 CVE-2025-39763 CVE-2025-39764 CVE-2025-39770 CVE-2025-39772 CVE-2025-39773 CVE-2025-39787 CVE-2025-39789 CVE-2025-39797 CVE-2025-39800 CVE-2025-39801 CVE-2025-39819 CVE-2025-39823 CVE-2025-39825 CVE-2025-39826 CVE-2025-39827 CVE-2025-39829 CVE-2025-39833 CVE-2025-39838 CVE-2025-39863 CVE-2025-39865 CVE-2025-39866 CVE-2025-39873 CVE-2025-39901 CVE-2025-39905 CVE-2025-39913 CVE-2025-39927 CVE-2025-39929 CVE-2025-39931 CVE-2025-39932 CVE-2025-39933 CVE-2025-39940 CVE-2025-39949 CVE-2025-39952 CVE-2025-39957 CVE-2025-39958 CVE-2025-39961 CVE-2025-39964 CVE-2025-39971 CVE-2025-39990 CVE-2025-40003 CVE-2025-40005 CVE-2025-40025 CVE-2025-40043 CVE-2025-40048 CVE-2025-40053 CVE-2025-40064 CVE-2025-40074 CVE-2025-40075 CVE-2025-40078 CVE-2025-40080 CVE-2025-40082 CVE-2025-40083 CVE-2025-40092 CVE-2025-40093 CVE-2025-40094 CVE-2025-40095 CVE-2025-40099 CVE-2025-40100 CVE-2025-40102 CVE-2025-40103 CVE-2025-40107 CVE-2025-40110 CVE-2025-40123 CVE-2025-40135 CVE-2025-40137 CVE-2025-40139 CVE-2025-40146 CVE-2025-40149 CVE-2025-40158 CVE-2025-40160 CVE-2025-40164 CVE-2025-40168 CVE-2025-40170 CVE-2025-40193 CVE-2025-40196 CVE-2025-40211 CVE-2025-40300 CVE-2025-4598), for more information check /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+f67c504655-r0/temp/cve.log
Image CVE report stored in: /home/deby/build/tmp/deploy/images/qemuarm64/core-image-minimal-qemuarm64-20251126105837.rootfs.cve
NOTE: Tasks Summary: Attempted 3181 tasks of which 2747 didn't need to be rerun and all succeeded.

Summary: There were 69 WARNING messages shown.
```

### Check to CVE check results

Comparing CVE check results before and after applying this PR, now detect CVEs that CPE is not set, indicating the fix is working.

Saved file:
- [before.log](https://github.com/user-attachments/files/23768572/before.log)
- [after.log](https://github.com/user-attachments/files/23768579/after.log)

Check count of CVEs increases/decreases:
```
$ diff -up before.log.output after.log.output | grep '^-CVE' -c
0
$ diff -up before.log.output after.log.output | grep '^+CVE' -c
927
```

Breakdown of CVEs increases:
```
$ diff -up before.log.output after.log.output | grep '^+CVE' | grep Patched -c
767
$ diff -up before.log.output after.log.output | grep '^+CVE' | grep Unpatched -c
160
```

Choice and verify three CVEs each from `Patched` and `Unpatched`:
- Patched
  ```
  $ diff -up before.log.output after.log.output | grep '^+CVE' | grep Patched | tail -n 5
  +CVE-2025-7709, Patched, sqlite3-native, 3.27.2
  +CVE-2025-9231, Patched, openssl, 1.1.1n
  +CVE-2025-9231, Patched, openssl-native, 1.1.1n
  +CVE-2025-9232, Patched, openssl, 1.1.1n
  +CVE-2025-9232, Patched, openssl-native, 1.1.1n
  ```
  - CVE-2025-9232
    - [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-9232): CPE is not set
    - [Debian](https://deb.freexian.com/extended-lts/tracker/CVE-2025-9232): `openssl (PTS)	buster (lts), buster	1.1.1n-0+deb10u7	fixed`
  - CVE-2025-9231
    - [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-9231): CPE is not set
    - [Debian](https://deb.freexian.com/extended-lts/tracker/CVE-2025-9231): `openssl (PTS)	buster (lts), buster	1.1.1n-0+deb10u7	fixed`
  - CVE-2025-7709
    - [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-7709): CPE is not set
    - [Debian](https://deb.freexian.com/extended-lts/tracker/CVE-2025-7709): `sqlite3 (PTS)	buster (lts), buster	3.27.2-3+deb10u3	fixed`

- Unpatched
  ```
  $ diff -up before.log.output after.log.output | grep '^+CVE' | grep Unpatched | tail -n 5
  +CVE-2025-8845, Unpatched, nasm-native, 2.14
  +CVE-2025-8846, Unpatched, nasm-native, 2.14
  +CVE-2025-9086, Unpatched, curl-native, 7.64.0
  +CVE-2025-9230, Unpatched, openssl, 1.1.1n
  +CVE-2025-9230, Unpatched, openssl-native, 1.1.1n
  ```
  - CVE-2025-9230
    - [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-9230): CPE is not set
    - [Debian](https://deb.freexian.com/extended-lts/tracker/CVE-2025-9230): `openssl (PTS)	buster (lts), buster	1.1.1n-0+deb10u7	vulnerable`
  - CVE-2025-9086
    - [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-9086): CPE is not set
    - [Debian](https://deb.freexian.com/extended-lts/tracker/CVE-2025-9086): `curl (PTS)	buster (lts), buster	7.64.0-4+deb10u12	vulnerable`
  - CVE-2025-8846
    - [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-8846): CPE is not set
    - [Debian](https://deb.freexian.com/extended-lts/tracker/CVE-2025-8846): `nasm (PTS)	buster	2.14-1	vulnerable`

### Check to recipes with unset CVE_PRODUCT skipped cve-check ###

Checked  to cve-check was skipped as expected in glibc-locale recipe.

Check the target recipe:
```
deby@be15cecd17af:~/poky$ grep -r -n 'CVE_PRODUCT = ""' 
meta/recipes-core/glibc/glibc-locale.inc:105:CVE_PRODUCT = ""
meta/recipes-core/glibc/glibc-scripts.inc:23:CVE_PRODUCT = ""
meta/recipes-core/glibc/glibc-mtrace.inc:16:CVE_PRODUCT = ""
meta/classes/image.bbclass:669:CVE_PRODUCT = ""
meta/classes/packagegroup.bbclass:61:CVE_PRODUCT = ""
```

#### glibc-locale ####

Checked to cve-check for glibc-locale was skipped.
```
deby@be15cecd17af:~/build$ cat ./tmp/work/aarch64-deby-linux/glibc-locale/2.28-r0/temp/log.do_cve_check
DEBUG: Executing python function debian_cve_check
DEBUG: Skip debian-cve-check because CVE_PRODUCT is unset.
DEBUG: Python function debian_cve_check finished
DEBUG: Executing python function do_cve_check
DEBUG: Looking for patches that solves CVEs for glibc-locale
DEBUG: CHECK_CVES_CALLBACK: None
DEBUG: Python function do_cve_check finished
```
```
$ grep -c 'glibc-locale' before.log
0
$ grep -c 'glibc-locale' after.log
0
```

#### glibc-scripts ####

glibc-scripts was not a build target.
```
deby@be15cecd17af:~/build$ find . -name '*glibc-scripts*'
```

#### glibc-mtrace ####

glibc-mtrace was not a build target.
```
deby@be15cecd17af:~/build$ find . -name '*glibc-mtrace*'
```
