### PR TITLE
cve-check: Fix to lack of separator space of registering callback function name

### DIFF
--- a/classes/cve-check.bbclass
+++ b/classes/cve-check.bbclass
@@ -75,6 +75,9 @@ python do_cve_check () {
         #
         # Then, registered with:
         #     CHECK_CVES_CALLBACK_append += "example_func"
+        #
+        # For Python code, add spaces before the function name:
+        #     d.appendVar("CHECK_CVES_CALLBACK", " example_func")
         callback_funcs = d.getVar("CHECK_CVES_CALLBACK")
         bb.debug(2, "CHECK_CVES_CALLBACK: %s" % callback_funcs)
         if isinstance(callback_funcs, str):

--- a/classes/debian-cve-check.bbclass
+++ b/classes/debian-cve-check.bbclass
@@ -82,7 +82,7 @@ python debian_cve_check () {
     d.setVar("DST_UNPATCHED_CVES", ' '.join(deb_unpatched))
 
     # Register to be called back from do_cve_check().
-    d.appendVar("CHECK_CVES_CALLBACK", "debian_check_cves_func")
+    d.appendVar("CHECK_CVES_CALLBACK", " debian_check_cves_func")
 }
 
 do_cve_check[prefuncs] += "debian_cve_check"

--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -222,7 +222,7 @@ python kernel_cve_check () {
     d.setVar("CIP_KERNEL_SEC_FIXED_CVES", " ".join(fixed_cves))
 
     # Register to be called back from do_cve_check().
-    d.appendVar("CHECK_CVES_CALLBACK", "kernel_check_cves_func")
+    d.appendVar("CHECK_CVES_CALLBACK", " kernel_check_cves_func")
 }
 
 do_cve_check[prefuncs] += "${@bb.utils.contains('PN', d.getVar('KERNEL_PN'), 'kernel_cve_check', '', d)}"


### PR DESCRIPTION
# Purpose of the Pull Request

Fix issue that lack of separator space when registering the cve-check callback function.

# Test
## How to test

### Prepare

1. Startup the Docker environment.
   ```
   $ cd meta-debian/docker
   $ make start
   ```

2. Setup build environment within Docker container
   ```
   deby@<container-id>:~$ export TEMPLATECONF=meta-debian/conf
   deby@<container-id>:~$ source ./poky/oe-init-build-env
   ```

3. Setting local.conf

   Add following line into conf/local.conf.
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   ```

### Test1: In the before this PR environment, for reproduce the issue

1. Create `meta-debian/classes/test-before-cve-check.bbclass` file

   Based on a previous mistake, register only the function name.
   ```
   meta-debian$ cat classes/test-before-cve-check.bbclass
   def test_before_check_cves_func(d, patched, unpatched):
       bb.warn("## test_before_check_cves_func()")
       return (patched, unpatched)
   
   python test_before_cve_check () {
       bb.warn("## test_before_cve_check()")
       d.appendVar("CHECK_CVES_CALLBACK", "test_before_check_cves_func")
   }
   do_cve_check[prefuncs] += "test_before_cve_check"
   ```

2. Setting local.conf

   Add following line into conf/local.conf.
   ```
   INHERIT += " cve-check debian-cve-check kernel-cve-check test-before-cve-check"
   ```

3. Run command

   ```
   $ bitbake bash -c cve_check
   ```

### Test2: In the after this PR environment, for confirm the issue has been resolved

1. Create `meta-debian/classes/test-after-cve-check.bbclass` file

   Correctly, register the function name with space added.
   ```
   meta-debian$ cat classes/test-after-cve-check.bbclass 
   def test_after_check_cves_func(d, patched, unpatched):
       bb.warn("## test_after_check_cves_func()")
       return (patched, unpatched)
   
   python test_after_cve_check () {
       bb.warn("## test_after_cve_check()")
       d.appendVar("CHECK_CVES_CALLBACK", " test_after_check_cves_func")
   }
   do_cve_check[prefuncs] += "test_after_cve_check"
   ```

2. Setting local.conf

   Add following line into conf/local.conf.
   ```
   INHERIT += " cve-check debian-cve-check kernel-cve-check test-after-cve-check"
   ```

3. Run command

   ```
   $ bitbake bash -c cve_check
   ```

## Test result
### Test1 result: In the before this PR environment, for reproduce the issue

As expected, the issue has been reproduced.
```
deby@038be0677e83:~/build$ bitbake bash -c cve_check
Parsing recipes: 100% |#################################################################################################| Time: 0:00:04
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-cve-check-register-callback-func-to-warrior:1c32170dd4e9db7b2fc7d4b12576bfce88300bd5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: bash-5.0-r0 do_cve_check: ## test_before_cve_check()
ERROR: bash-5.0-r0 do_cve_check: Error executing a python function in exec_python_func() autogenerated:

The stack trace of python calls that resulted in this exception/failure was:
File: 'exec_python_func() autogenerated', lineno: 2, function: <module>
     0001:
 *** 0002:do_cve_check(d)
     0003:
File: '/home/deby/poky/meta-debian/classes/cve-check.bbclass', lineno: 86, function: do_cve_check
     0082:        bb.debug(2, "CHECK_CVES_CALLBACK: %s" % callback_funcs)
     0083:        if isinstance(callback_funcs, str):
     0084:            for callback_func in callback_funcs.split():
     0085:                bb.note("Call to '%s' function." % callback_func)
 *** 0086:                patched, unpatched = eval(callback_func)(d, patched, unpatched)
     0087:
     0088:        if patched or unpatched:
     0089:            cve_data = get_cve_info(d, patched + unpatched)
     0090:            cve_write_data(d, patched, unpatched, cve_data)
File: '<string>', lineno: 1, function: <module>
  File "<string>", line 1, in <module>

Exception: NameError: name 'debian_check_cves_functest_before_check_cves_func' is not defined

ERROR: bash-5.0-r0 do_cve_check: name 'debian_check_cves_functest_before_check_cves_func' is not defined
ERROR: bash-5.0-r0 do_cve_check: Function failed: do_cve_check
ERROR: Logfile of failure stored in: /home/deby/build/tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/log.do_cve_check.1949931
ERROR: Task (/home/deby/poky/meta-debian/recipes-debian/bash/bash_debian.bb:do_cve_check) failed with exit code '1'
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /home/deby/poky/meta-debian/recipes-debian/bash/bash_debian.bb:do_cve_check
Summary: There was 1 WARNING message shown.
Summary: There were 3 ERROR messages shown, returning a non-zero exit code.
```

### Test2 result: In the after this PR environment, for confirm the issue has been resolved

The registered callback function is called and completes successfully.
```
deby@038be0677e83:~/build$ bitbake bash -c cve_check
Parsing recipes: 100% |#################################################################################################| Time: 0:00:04
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-cve-check-register-callback-func-to-warrior:1c32170dd4e9db7b2fc7d4b12576bfce88300bd5"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
NOTE: Executing RunQueue Tasks
WARNING: bash-5.0-r0 do_cve_check: ## test_after_cve_check()
WARNING: bash-5.0-r0 do_cve_check: ## test_after_check_cves_func()
WARNING: bash-5.0-r0 do_cve_check: Found unpatched CVE (CVE-2019-18276), for more information check /home/deby/build/tmp/work/aarch64-deby-linux/bash/5.0-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 2 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There were 3 WARNING messages shown.
```