### PR TITLE
kernel-cve-check: Raise error instead of warning on report_affected.py failure

### DIFF
--- a/classes/kernel-cve-check.bbclass
+++ b/classes/kernel-cve-check.bbclass
@@ -184,7 +184,7 @@ python kernel_cve_check () {
     try:
         runfetchcmd(cmd, d, workdir=cip_kernel_sec_path)
     except bb.fetch2.FetchError as e:
-        bb.warn("Failed to run report_affected.py: %s" % (e))
+        bb.error("Failed to run report_affected.py: %s" % (e))
 
     fixed_cves = []
     tmp_affected_cves = []


### PR DESCRIPTION
# Purpose of the Pull Request

A bitbake WARNING will continue processing, but it is difficult to notice that the CVE check results are incorrect.
Therefore, bitbake will terminate with an ERROR if report_affected.py fails.

# Test
## How to test
1. Startup the Docker environment
   ```
   $ cd meta-debian/docker
   $ make start
   ```

2. Setup build environment
   ```
   deby@<container-id>:~$ export TEMPLATECONF=meta-debian/conf
   deby@<container-id>:~$ source ./poky/oe-init-build-env
   ```

3. Setting local.conf
   Add following line into conf/local.conf.
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   INHERIT += " cve-check debian-cve-check kernel-cve-check"
   ```

   (Optional) If do_fetch error occurs of the debian package, follow doc/6.security-update.md to enable security updates.
   ```
   DEBIAN_SOURCE_ENABLED = "1"
   DEBIAN_SRC_FORCE_REGEN = "1"
   DEBIAN_SECURITY_UPDATE_ENABLED = "1"
   ```

4. Check Kernel's cve-check is OK
   Run following command, expect success.
   ```
   bitbake linux-base -c cve_check
   ```

5. Remove packages on Docker container
   ```
   sudo apt remove python3-html5lib python3-requests
   ```

6. Check Kernel's cve-check is ERROR (caused by python3-requests)
   Run following command, expect ERROR caused by "python3-requests".
   ```
   bitbake linux-base -c cve_check
   ```

7. Install "python3-requests" package
   Run following command, install "python3-requests" package to Docker container..
   ```
   sudo apt install python3-requests
   ```

8. Check Kernel's cve-check is ERROR (caused by python3-html5lib)
   Run following command, expect ERROR caused by "python3-html5lib".
   ```
   bitbake linux-base -c cve_check
   ```

9. Install "python3-html5lib" package
   Run following command, install "python3-html5lib" package to Docker container..
   ```
   sudo apt install python3-html5lib
   ```

10. Check Kernel's cve-check is OK
    Run following command, expect success.
    ```
    bitbake linux-base -c cve_check
    ```

## Test result
Confirmed that an ERROR message was displayed instead of a WARNING message, as expected.

### 4. Check Kernel's cve-check is OK
```
deby@5625c6a8d2a2:~/build$ bitbake linux-base -c cve_check
WARNING: debian security update repository is enabled
WARNING: debian ELTS security update repository is enabled
Checking Debian Release ... http://deb.freexian.com/extended-lts/dists/buster-lts/Release
Fetching Debian Sources.gz ... http://deb.freexian.com/extended-lts/dists/buster-lts/main/source/Sources.gz;md5sum=6bdb23be91bee4e1fa363bd2198c1d4c
Parsing Debian Sources.gz ...
Checking Debian Release ... http://archive.debian.org/debian-security/dists/buster/updates/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian-security/dists/buster/updates/main/source/Sources.gz;md5sum=e3bb28be0cf1fb769d3c63c037fc5bf8
Parsing Debian Sources.gz ...
Checking Debian Release ... http://archive.debian.org/debian/dists/buster/Release
Fetching Debian Sources.gz ... http://archive.debian.org/debian/dists/buster/main/source/Sources.gz;md5sum=60b1a2c60363095f2871f4a056e36980
Parsing Debian Sources.gz ...
Parsing recipes: 100% |#################################################################################################| Time: 0:00:05
Parsing of 1043 .bb files complete (0 cached, 1043 parsed). 1825 targets, 72 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "fix-error-handling-of-kernel-cve-check-to-warrior:c6e8083b5208a531ddcfae89f0ae2119d7c427ac"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 42 Found 0 Missed 42 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: linux-base-4.19+gitAUTOINC+ef917a8bed-r0 do_cve_check: Found unpatched CVE (CVE-1999-0524 CVE-1999-0656 CVE-2006-2932 CVE-2007-2764 CVE-2007-4998 CVE-2008-2544 CVE-2008-4609 CVE-2010-4563 CVE-2010-5321 CVE-2015-2877 CVE-2015-7312 CVE-2016-3699 CVE-2017-1000377 CVE-2017-6264 CVE-2018-1121 CVE-2019-0149 CVE-2019-11191 CVE-2019-12378 CVE-2019-12379 CVE-2019-12380 CVE-2019-12381 CVE-2019-12382 CVE-2019-12454 CVE-2019-12455 CVE-2019-12456 CVE-2019-14899 CVE-2019-16089 CVE-2019-19083 CVE-2019-20794 CVE-2020-0347 CVE-2020-11725 CVE-2020-12362 CVE-2020-12363 CVE-2020-12364 CVE-2020-15802 CVE-2020-16120 CVE-2020-26140 CVE-2020-26141 CVE-2020-26142 CVE-2020-26143 CVE-2020-26144 CVE-2020-26145 CVE-2020-26146 CVE-2020-26541 CVE-2020-26556 CVE-2020-26557 CVE-2020-26559 CVE-2020-26560 CVE-2020-27820 CVE-2020-27835 CVE-2020-35501 CVE-2020-36310 CVE-2020-36385 CVE-2020-36691 CVE-2020-36766 CVE-2020-36780 CVE-2020-36782 CVE-2020-36783 CVE-2020-36784 CVE-2021-0399 CVE-2021-0929 CVE-2021-0961 CVE-2021-1076 CVE-2021-1077 CVE-2021-26934 CVE-2021-29256 CVE-2021-31615 CVE-2021-32078 CVE-2021-33061 CVE-2021-33096 CVE-2021-3492 CVE-2021-3669 CVE-2021-3714 CVE-2021-3773 CVE-2021-3847 CVE-2021-3864 CVE-2021-3923 CVE-2021-39800 CVE-2021-39801 CVE-2021-39802 CVE-2021-4037 CVE-2021-4460 CVE-2021-46925 CVE-2021-46928 CVE-2021-46941 CVE-2021-46984 CVE-2021-47049 CVE-2021-47063 CVE-2021-47074 CVE-2021-47076 CVE-2021-47077 CVE-2021-47101 CVE-2021-47110 CVE-2021-47112 CVE-2021-47113 CVE-2021-47119 CVE-2021-47131 CVE-2021-47143 CVE-2021-47163 CVE-2021-47167 CVE-2021-47182 CVE-2021-47183 CVE-2021-47188 CVE-2021-47191 CVE-2021-47201 CVE-2021-47202 CVE-2021-47204 CVE-2021-47205 CVE-2021-47211 CVE-2021-47219 CVE-2021-47224 CVE-2021-47234 CVE-2021-47246 CVE-2021-47265 CVE-2021-47275 CVE-2021-47281 CVE-2021-47307 CVE-2021-47329 CVE-2021-47335 CVE-2021-47350 CVE-2021-47351 CVE-2021-47354 CVE-2021-47362 CVE-2021-47366 CVE-2021-47378 CVE-2021-47379 CVE-2021-47391 CVE-2021-47396 CVE-2021-47407 CVE-2021-47408 CVE-2021-47410 CVE-2021-47412 CVE-2021-47414 CVE-2021-47431 CVE-2021-47438 CVE-2021-47441 CVE-2021-47455 CVE-2021-47466 CVE-2021-47473 CVE-2021-47479 CVE-2021-47493 CVE-2021-47496 CVE-2021-47498 CVE-2021-47501 CVE-2021-47508 CVE-2021-47523 CVE-2021-47544 CVE-2021-47559 CVE-2021-47582 CVE-2021-47597 CVE-2021-47599 CVE-2021-47618 CVE-2021-47635 CVE-2021-47644 CVE-2021-47648 CVE-2021-47653 CVE-2022-0168 CVE-2022-0400 CVE-2022-0480 CVE-2022-1015 CVE-2022-1247 CVE-2022-20158 CVE-2022-21499 CVE-2022-23825 CVE-2022-25265 CVE-2022-25836 CVE-2022-25837 CVE-2022-26047 CVE-2022-27672 CVE-2022-28667 CVE-2022-29582 CVE-2022-2961 CVE-2022-3108 CVE-2022-3303 CVE-2022-3344 CVE-2022-3523 CVE-2022-36397 CVE-2022-36402 CVE-2022-39189 CVE-2022-4129 CVE-2022-41848 CVE-2022-43945 CVE-2022-44032 CVE-2022-44033 CVE-2022-44034 CVE-2022-4543 CVE-2022-45885 CVE-2022-47520 CVE-2022-48628 CVE-2022-48631 CVE-2022-48633 CVE-2022-48664 CVE-2022-48673 CVE-2022-48674 CVE-2022-48731 CVE-2022-48733 CVE-2022-48734 CVE-2022-48744 CVE-2022-48751 CVE-2022-48755 CVE-2022-48761 CVE-2022-48763 CVE-2022-48765 CVE-2022-48769 CVE-2022-48772 CVE-2022-48792 CVE-2022-48802 CVE-2022-48806 CVE-2022-48811 CVE-2022-48825 CVE-2022-48827 CVE-2022-48863 CVE-2022-48865 CVE-2022-48875 CVE-2022-48901 CVE-2022-48902 CVE-2022-48920 CVE-2022-48953 CVE-2022-48961 CVE-2022-48975 CVE-2022-48986 CVE-2022-49006 CVE-2022-49013 CVE-2022-49019 CVE-2022-49026 CVE-2022-49027 CVE-2022-49028 CVE-2022-49046 CVE-2022-49065 CVE-2022-49067 CVE-2022-49106 CVE-2022-49107 CVE-2022-49110 CVE-2022-49117 CVE-2022-49118 CVE-2022-49119 CVE-2022-49120 CVE-2022-49121 CVE-2022-49124 CVE-2022-49135 CVE-2022-49138 CVE-2022-49139 CVE-2022-49149 CVE-2022-49154 CVE-2022-49156 CVE-2022-49157 CVE-2022-49158 CVE-2022-49164 CVE-2022-49168 CVE-2022-49169 CVE-2022-49170 CVE-2022-49172 CVE-2022-49178 CVE-2022-49179 CVE-2022-49188 CVE-2022-49189 CVE-2022-49190 CVE-2022-49194 CVE-2022-49196 CVE-2022-49220 CVE-2022-49226 CVE-2022-49241 CVE-2022-49255 CVE-2022-49258 CVE-2022-49267 CVE-2022-49285 CVE-2022-49286 CVE-2022-49289 CVE-2022-49296 CVE-2022-49301 CVE-2022-49309 CVE-2022-49311 CVE-2022-49312 CVE-2022-49317 CVE-2022-49318 CVE-2022-49319 CVE-2022-49320 CVE-2022-49323 CVE-2022-49325 CVE-2022-49327 CVE-2022-49328 CVE-2022-49336 CVE-2022-49342 CVE-2022-49360 CVE-2022-49361 CVE-2022-49363 CVE-2022-49364 CVE-2022-49371 CVE-2022-49373 CVE-2022-49376 CVE-2022-49380 CVE-2022-49385 CVE-2022-49390 CVE-2022-49398 CVE-2022-49409 CVE-2022-49411 CVE-2022-49413 CVE-2022-49414 CVE-2022-49420 CVE-2022-49428 CVE-2022-49431 CVE-2022-49437 CVE-2022-49440 CVE-2022-49443 CVE-2022-49445 CVE-2022-49462 CVE-2022-49465 CVE-2022-49468 CVE-2022-49486 CVE-2022-49497 CVE-2022-49504 CVE-2022-49512 CVE-2022-49513 CVE-2022-49519 CVE-2022-49520 CVE-2022-49521 CVE-2022-49522 CVE-2022-49528 CVE-2022-49531 CVE-2022-49534 CVE-2022-49545 CVE-2022-49546 CVE-2022-49555 CVE-2022-49563 CVE-2022-49564 CVE-2022-49566 CVE-2022-49568 CVE-2022-49577 CVE-2022-49578 CVE-2022-49579 CVE-2022-49580 CVE-2022-49584 CVE-2022-49585 CVE-2022-49596 CVE-2022-49597 CVE-2022-49599 CVE-2022-49603 CVE-2022-49610 CVE-2022-49622 CVE-2022-49623 CVE-2022-49630 CVE-2022-49632 CVE-2022-49635 CVE-2022-49640 CVE-2022-49641 CVE-2022-49644 CVE-2022-49650 CVE-2022-49651 CVE-2022-49658 CVE-2022-49668 CVE-2022-49693 CVE-2022-49698 CVE-2022-49710 CVE-2022-49720 CVE-2022-49728 CVE-2022-49733 CVE-2022-49740 CVE-2022-49741 CVE-2022-49742 CVE-2022-49749 CVE-2022-49758 CVE-2022-49761 CVE-2022-49764 CVE-2022-49765 CVE-2022-49766 CVE-2022-49789 CVE-2022-49799 CVE-2022-49813 CVE-2022-49823 CVE-2022-49824 CVE-2022-49825 CVE-2022-49828 CVE-2022-49829 CVE-2022-49838 CVE-2022-49839 CVE-2022-49879 CVE-2022-49892 CVE-2022-49898 CVE-2022-49913 CVE-2022-49923 CVE-2022-49924 CVE-2022-49925 CVE-2022-49932 CVE-2022-49937 CVE-2022-49938 CVE-2022-49954 CVE-2022-49967 CVE-2022-49975 CVE-2022-49980 CVE-2022-49989 CVE-2022-49998 CVE-2022-50009 CVE-2022-50021 CVE-2022-50023 CVE-2022-50030 CVE-2022-50036 CVE-2022-50047 CVE-2022-50053 CVE-2022-50055 CVE-2022-50062 CVE-2022-50065 CVE-2022-50066 CVE-2022-50073 CVE-2022-50086 CVE-2022-50092 CVE-2022-50093 CVE-2022-50098 CVE-2022-50103 CVE-2022-50108 CVE-2022-50114 CVE-2022-50116 CVE-2022-50120 CVE-2022-50129 CVE-2022-50138 CVE-2022-50144 CVE-2022-50146 CVE-2022-50159 CVE-2022-50163 CVE-2022-50166 CVE-2022-50174 CVE-2022-50175 CVE-2022-50181 CVE-2022-50226 CVE-2022-50236 CVE-2022-50246 CVE-2022-50256 CVE-2022-50260 CVE-2022-50266 CVE-2022-50267 CVE-2022-50293 CVE-2022-50300 CVE-2022-50304 CVE-2022-50313 CVE-2022-50316 CVE-2022-50335 CVE-2022-50340 CVE-2022-50341 CVE-2022-50350 CVE-2022-50356 CVE-2022-50358 CVE-2022-50364 CVE-2022-50374 CVE-2022-50375 CVE-2022-50376 CVE-2022-50385 CVE-2022-50395 CVE-2022-50406 CVE-2022-50410 CVE-2022-50412 CVE-2022-50422 CVE-2022-50439 CVE-2022-50443 CVE-2022-50445 CVE-2022-50453 CVE-2022-50456 CVE-2022-50469 CVE-2022-50471 CVE-2022-50485 CVE-2022-50492 CVE-2022-50500 CVE-2022-50511 CVE-2022-50513 CVE-2022-50518 CVE-2022-50527 CVE-2022-50532 CVE-2022-50539 CVE-2022-50549 CVE-2022-50550 CVE-2022-50552 CVE-2022-50554 CVE-2022-50556 CVE-2022-50560 CVE-2022-50562 CVE-2022-50574 CVE-2022-50580 CVE-2022-50614 CVE-2022-50616 CVE-2022-50630 CVE-2022-50647 CVE-2022-50670 CVE-2022-50700 CVE-2022-50708 CVE-2022-50720 CVE-2022-50746 CVE-2022-50751 CVE-2022-50753 CVE-2022-50756 CVE-2022-50764 CVE-2022-50766 CVE-2022-50770 CVE-2022-50771 CVE-2022-50774 CVE-2022-50815 CVE-2022-50817 CVE-2022-50832 CVE-2022-50860 CVE-2022-50864 CVE-2022-50865 CVE-2022-50879 CVE-2022-50881 CVE-2022-50889 CVE-2023-1076 CVE-2023-1249 CVE-2023-1476 CVE-2023-1582 CVE-2023-1611 CVE-2023-20569 CVE-2023-20588 CVE-2023-20928 CVE-2023-20938 CVE-2023-20941 CVE-2023-2124 CVE-2023-2177 CVE-2023-23000 CVE-2023-23039 CVE-2023-24023 CVE-2023-26242 CVE-2023-28466 CVE-2023-28746 CVE-2023-3079 CVE-2023-32256 CVE-2023-33288 CVE-2023-3397 CVE-2023-3640 CVE-2023-37453 CVE-2023-37454 CVE-2023-3863 CVE-2023-39176 CVE-2023-39179 CVE-2023-39180 CVE-2023-39197 CVE-2023-39198 CVE-2023-4010 CVE-2023-4133 CVE-2023-4134 CVE-2023-51779 CVE-2023-52458 CVE-2023-52474 CVE-2023-52481 CVE-2023-52485 CVE-2023-52488 CVE-2023-52491 CVE-2023-52498 CVE-2023-52500 CVE-2023-52515 CVE-2023-52522 CVE-2023-52530 CVE-2023-52531 CVE-2023-52572 CVE-2023-52586 CVE-2023-52588 CVE-2023-52590 CVE-2023-52591 CVE-2023-52614 CVE-2023-52624 CVE-2023-52629 CVE-2023-52635 CVE-2023-52639 CVE-2023-52642 CVE-2023-52652 CVE-2023-52653 CVE-2023-52664 CVE-2023-52669 CVE-2023-52671 CVE-2023-52700 CVE-2023-52708 CVE-2023-52732 CVE-2023-52736 CVE-2023-52741 CVE-2023-52743 CVE-2023-52745 CVE-2023-52752 CVE-2023-52754 CVE-2023-52760 CVE-2023-52781 CVE-2023-52784 CVE-2023-52811 CVE-2023-52821 CVE-2023-52828 CVE-2023-52834 CVE-2023-52854 CVE-2023-52871 CVE-2023-52878 CVE-2023-52882 CVE-2023-52888 CVE-2023-52925 CVE-2023-52996 CVE-2023-53000 CVE-2023-53008 CVE-2023-53010 CVE-2023-53020 CVE-2023-53031 CVE-2023-53039 CVE-2023-53042 CVE-2023-53068 CVE-2023-53079 CVE-2023-53080 CVE-2023-53091 CVE-2023-53093 CVE-2023-53094 CVE-2023-53103 CVE-2023-53111 CVE-2023-53118 CVE-2023-53131 CVE-2023-53135 CVE-2023-53149 CVE-2023-53171 CVE-2023-53178 CVE-2023-53200 CVE-2023-53201 CVE-2023-53217 CVE-2023-53218 CVE-2023-53225 CVE-2023-53241 CVE-2023-53244 CVE-2023-53248 CVE-2023-53250 CVE-2023-53254 CVE-2023-53270 CVE-2023-53280 CVE-2023-53282 CVE-2023-53288 CVE-2023-53326 CVE-2023-53332 CVE-2023-53333 CVE-2023-53335 CVE-2023-53338 CVE-2023-53346 CVE-2023-53348 CVE-2023-53368 CVE-2023-53369 CVE-2023-53370 CVE-2023-53383 CVE-2023-53391 CVE-2023-53393 CVE-2023-53397 CVE-2023-53415 CVE-2023-53429 CVE-2023-53432 CVE-2023-53433 CVE-2023-53438 CVE-2023-53441 CVE-2023-53443 CVE-2023-53446 CVE-2023-53447 CVE-2023-53458 CVE-2023-53468 CVE-2023-53476 CVE-2023-53477 CVE-2023-53482 CVE-2023-53491 CVE-2023-53499 CVE-2023-53503 CVE-2023-53505 CVE-2023-53509 CVE-2023-53510 CVE-2023-53512 CVE-2023-53513 CVE-2023-53517 CVE-2023-53538 CVE-2023-53539 CVE-2023-53540 CVE-2023-53544 CVE-2023-53545 CVE-2023-53556 CVE-2023-53562 CVE-2023-53577 CVE-2023-53579 CVE-2023-53584 CVE-2023-53586 CVE-2023-53588 CVE-2023-53589 CVE-2023-53594 CVE-2023-53596 CVE-2023-53607 CVE-2023-53612 CVE-2023-53615 CVE-2023-53620 CVE-2023-53624 CVE-2023-53625 CVE-2023-53627 CVE-2023-53635 CVE-2023-53647 CVE-2023-53651 CVE-2023-53661 CVE-2023-53679 CVE-2023-53680 CVE-2023-53682 CVE-2023-53685 CVE-2023-53692 CVE-2023-53696 CVE-2023-53707 CVE-2023-53712 CVE-2023-53718 CVE-2023-53733 CVE-2023-53748 CVE-2023-53754 CVE-2023-53756 CVE-2023-53765 CVE-2023-53781 CVE-2023-53794 CVE-2023-53799 CVE-2023-53816 CVE-2023-53824 CVE-2023-53829 CVE-2023-53834 CVE-2023-53840 CVE-2023-53846 CVE-2023-53849 CVE-2023-53850 CVE-2023-53856 CVE-2023-53859 CVE-2023-53867 CVE-2023-53986 CVE-2023-53992 CVE-2023-53995 CVE-2023-54001 CVE-2023-54003 CVE-2023-54012 CVE-2023-54023 CVE-2023-54028 CVE-2023-54047 CVE-2023-54048 CVE-2023-54057 CVE-2023-54067 CVE-2023-54069 CVE-2023-54081 CVE-2023-54098 CVE-2023-54118 CVE-2023-54119 CVE-2023-54121 CVE-2023-54126 CVE-2023-54132 CVE-2023-54145 CVE-2023-54150 CVE-2023-54153 CVE-2023-54158 CVE-2023-54180 CVE-2023-54184 CVE-2023-54185 CVE-2023-54187 CVE-2023-54202 CVE-2023-54236 CVE-2023-54243 CVE-2023-54246 CVE-2023-54267 CVE-2023-54268 CVE-2023-54274 CVE-2023-54281 CVE-2023-54287 CVE-2023-54289 CVE-2023-54299 CVE-2023-54311 CVE-2023-54322 CVE-2023-54324 CVE-2023-6121 CVE-2023-6240 CVE-2023-6535 CVE-2023-6610 CVE-2024-0193 CVE-2024-1151 CVE-2024-14027 CVE-2024-21803 CVE-2024-21823 CVE-2024-2193 CVE-2024-2201 CVE-2024-23307 CVE-2024-25740 CVE-2024-25743 CVE-2024-26584 CVE-2024-26586 CVE-2024-26595 CVE-2024-26614 CVE-2024-26622 CVE-2024-26640 CVE-2024-26641 CVE-2024-26656 CVE-2024-26659 CVE-2024-26668 CVE-2024-26677 CVE-2024-26686 CVE-2024-26687 CVE-2024-26691 CVE-2024-26700 CVE-2024-26706 CVE-2024-26715 CVE-2024-26726 CVE-2024-26733 CVE-2024-26736 CVE-2024-26739 CVE-2024-26740 CVE-2024-26743 CVE-2024-26747 CVE-2024-26756 CVE-2024-26757 CVE-2024-26758 CVE-2024-26759 CVE-2024-26769 CVE-2024-26771 CVE-2024-26804 CVE-2024-26810 CVE-2024-26812 CVE-2024-26813 CVE-2024-26828 CVE-2024-26830 CVE-2024-26844 CVE-2024-26865 CVE-2024-26866 CVE-2024-26869 CVE-2024-26872 CVE-2024-26876 CVE-2024-26882 CVE-2024-26910 CVE-2024-26915 CVE-2024-26921 CVE-2024-26925 CVE-2024-26960 CVE-2024-26961 CVE-2024-26996 CVE-2024-27004 CVE-2024-27010 CVE-2024-27011 CVE-2024-27019 CVE-2024-27025 CVE-2024-27032 CVE-2024-27037 CVE-2024-27051 CVE-2024-27054 CVE-2024-27062 CVE-2024-27072 CVE-2024-27073 CVE-2024-27297 CVE-2024-27402 CVE-2024-27403 CVE-2024-27415 CVE-2024-27437 CVE-2024-28956 CVE-2024-35247 CVE-2024-35784 CVE-2024-35790 CVE-2024-35791 CVE-2024-35794 CVE-2024-35799 CVE-2024-35803 CVE-2024-35805 CVE-2024-35808 CVE-2024-35826 CVE-2024-35837 CVE-2024-35839 CVE-2024-35863 CVE-2024-35864 CVE-2024-35865 CVE-2024-35868 CVE-2024-35870 CVE-2024-35871 CVE-2024-35875 CVE-2024-35887 CVE-2024-35896 CVE-2024-35904 CVE-2024-35931 CVE-2024-35932 CVE-2024-35950 CVE-2024-35965 CVE-2024-35966 CVE-2024-35967 CVE-2024-35995 CVE-2024-36009 CVE-2024-36013 CVE-2024-36029 CVE-2024-36270 CVE-2024-36331 CVE-2024-36347 CVE-2024-36350 CVE-2024-36357 CVE-2024-36479 CVE-2024-36880 CVE-2024-36901 CVE-2024-36914 CVE-2024-36915 CVE-2024-36917 CVE-2024-36922 CVE-2024-36924 CVE-2024-36939 CVE-2024-36952 CVE-2024-36953 CVE-2024-36968 CVE-2024-37021 CVE-2024-37354 CVE-2024-38544 CVE-2024-38545 CVE-2024-38546 CVE-2024-38547 CVE-2024-38553 CVE-2024-38570 CVE-2024-38580 CVE-2024-38588 CVE-2024-38597 CVE-2024-38608 CVE-2024-38611 CVE-2024-38630 CVE-2024-39467 CVE-2024-39490 CVE-2024-39494 CVE-2024-39495 CVE-2024-40905 CVE-2024-40911 CVE-2024-40927 CVE-2024-40929 CVE-2024-40961 CVE-2024-40965 CVE-2024-40966 CVE-2024-40967 CVE-2024-40971 CVE-2024-40972 CVE-2024-40977 CVE-2024-40980 CVE-2024-40990 CVE-2024-40995 CVE-2024-40998 CVE-2024-40999 CVE-2024-41005 CVE-2024-41008 CVE-2024-41013 CVE-2024-41014 CVE-2024-41023 CVE-2024-41060 CVE-2024-41062 CVE-2024-41064 CVE-2024-41065 CVE-2024-41070 CVE-2024-41073 CVE-2024-41077 CVE-2024-41078 CVE-2024-41079 CVE-2024-41935 CVE-2024-42063 CVE-2024-42068 CVE-2024-42077 CVE-2024-42080 CVE-2024-42082 CVE-2024-42098 CVE-2024-42110 CVE-2024-42114 CVE-2024-42120 CVE-2024-42122 CVE-2024-42124 CVE-2024-42129 CVE-2024-42155 CVE-2024-42156 CVE-2024-42160 CVE-2024-42225 CVE-2024-42244 CVE-2024-42252 CVE-2024-42253 CVE-2024-42267 CVE-2024-42281 CVE-2024-42306 CVE-2024-42312 CVE-2024-42319 CVE-2024-42322 CVE-2024-43819 CVE-2024-43831 CVE-2024-43863 CVE-2024-43866 CVE-2024-43867 CVE-2024-43872 CVE-2024-43892 CVE-2024-43900 CVE-2024-43902 CVE-2024-43905 CVE-2024-43907 CVE-2024-43909 CVE-2024-43912 CVE-2024-44938 CVE-2024-44939 CVE-2024-44940 CVE-2024-44942 CVE-2024-44949 CVE-2024-44950 CVE-2024-44958 CVE-2024-44963 CVE-2024-44982 CVE-2024-44995 CVE-2024-45003 CVE-2024-45015 CVE-2024-46676 CVE-2024-46679 CVE-2024-46681 CVE-2024-46689 CVE-2024-46695 CVE-2024-46702 CVE-2024-46707 CVE-2024-46713 CVE-2024-46714 CVE-2024-46715 CVE-2024-46716 CVE-2024-46720 CVE-2024-46724 CVE-2024-46731 CVE-2024-46751 CVE-2024-46752 CVE-2024-46753 CVE-2024-46754 CVE-2024-46763 CVE-2024-46770 CVE-2024-46774 CVE-2024-46775 CVE-2024-46783 CVE-2024-46787 CVE-2024-46802 CVE-2024-46809 CVE-2024-46818 CVE-2024-46822 CVE-2024-46826 CVE-2024-46832 CVE-2024-46834 CVE-2024-46841 CVE-2024-46848 CVE-2024-46849 CVE-2024-46859 CVE-2024-47141 CVE-2024-47143 CVE-2024-47658 CVE-2024-47660 CVE-2024-47673 CVE-2024-47678 CVE-2024-47683 CVE-2024-47690 CVE-2024-47691 CVE-2024-47726 CVE-2024-47735 CVE-2024-47745 CVE-2024-47809 CVE-2024-49571 CVE-2024-49851 CVE-2024-49858 CVE-2024-49859 CVE-2024-49868 CVE-2024-49875 CVE-2024-49879 CVE-2024-49889 CVE-2024-49890 CVE-2024-49891 CVE-2024-49899 CVE-2024-49901 CVE-2024-49906 CVE-2024-49914 CVE-2024-49920 CVE-2024-49921 CVE-2024-49922 CVE-2024-49923 CVE-2024-49925 CVE-2024-49927 CVE-2024-49929 CVE-2024-49940 CVE-2024-49945 CVE-2024-49950 CVE-2024-49989 CVE-2024-49991 CVE-2024-49992 CVE-2024-50015 CVE-2024-50017 CVE-2024-50033 CVE-2024-50036 CVE-2024-50038 CVE-2024-50039 CVE-2024-50058 CVE-2024-50059 CVE-2024-50067 CVE-2024-50082 CVE-2024-50095 CVE-2024-50115 CVE-2024-50134 CVE-2024-50135 CVE-2024-50166 CVE-2024-50187 CVE-2024-50199 CVE-2024-50211 CVE-2024-50217 CVE-2024-50233 CVE-2024-50256 CVE-2024-50258 CVE-2024-50272 CVE-2024-50280 CVE-2024-50289 CVE-2024-50304 CVE-2024-52559 CVE-2024-53058 CVE-2024-53088 CVE-2024-53090 CVE-2024-53093 CVE-2024-53095 CVE-2024-53114 CVE-2024-53144 CVE-2024-53145 CVE-2024-53148 CVE-2024-53168 CVE-2024-53179 CVE-2024-53190 CVE-2024-53195 CVE-2024-53210 CVE-2024-53218 CVE-2024-53224 CVE-2024-53241 CVE-2024-53685 CVE-2024-54683 CVE-2024-56369 CVE-2024-56533 CVE-2024-56551 CVE-2024-56558 CVE-2024-56565 CVE-2024-56566 CVE-2024-56568 CVE-2024-56583 CVE-2024-56586 CVE-2024-56588 CVE-2024-56589 CVE-2024-56590 CVE-2024-56591 CVE-2024-56592 CVE-2024-56594 CVE-2024-56599 CVE-2024-56604 CVE-2024-56611 CVE-2024-56614 CVE-2024-56615 CVE-2024-56616 CVE-2024-56623 CVE-2024-56640 CVE-2024-56641 CVE-2024-56642 CVE-2024-56647 CVE-2024-56651 CVE-2024-56658 CVE-2024-56662 CVE-2024-56688 CVE-2024-56692 CVE-2024-56698 CVE-2024-56703 CVE-2024-56722 CVE-2024-56756 CVE-2024-56759 CVE-2024-56763 CVE-2024-56776 CVE-2024-56777 CVE-2024-56778 CVE-2024-57795 CVE-2024-57872 CVE-2024-57883 CVE-2024-57887 CVE-2024-57888 CVE-2024-57890 CVE-2024-57893 CVE-2024-57897 CVE-2024-57903 CVE-2024-57924 CVE-2024-57939 CVE-2024-57951 CVE-2024-57974 CVE-2024-57975 CVE-2024-57976 CVE-2024-57977 CVE-2024-57982 CVE-2024-58005 CVE-2024-58053 CVE-2024-58072 CVE-2024-58085 CVE-2024-58094 CVE-2024-58095 CVE-2024-58241 CVE-2024-8805 CVE-2025-21629 CVE-2025-21634 CVE-2025-21635 CVE-2025-21648 CVE-2025-21653 CVE-2025-21682 CVE-2025-21690 CVE-2025-21697 CVE-2025-21708 CVE-2025-21711 CVE-2025-21712 CVE-2025-21731 CVE-2025-21738 CVE-2025-21758 CVE-2025-21759 CVE-2025-21768 CVE-2025-21792 CVE-2025-21796 CVE-2025-21801 CVE-2025-21802 CVE-2025-21806 CVE-2025-21812 CVE-2025-21816 CVE-2025-21820 CVE-2025-21831 CVE-2025-21838 CVE-2025-21855 CVE-2025-21862 CVE-2025-21881 CVE-2025-21891 CVE-2025-21899 CVE-2025-21931 CVE-2025-21941 CVE-2025-21957 CVE-2025-21976 CVE-2025-21985 CVE-2025-21999 CVE-2025-22022 CVE-2025-22025 CVE-2025-22027 CVE-2025-22028 CVE-2025-22053 CVE-2025-22055 CVE-2025-22057 CVE-2025-22060 CVE-2025-22072 CVE-2025-22083 CVE-2025-22090 CVE-2025-22104 CVE-2025-22109 CVE-2025-22125 CVE-2025-23131 CVE-2025-23156 CVE-2025-23161 CVE-2025-27558 CVE-2025-37739 CVE-2025-37742 CVE-2025-37756 CVE-2025-37765 CVE-2025-37800 CVE-2025-37807 CVE-2025-37808 CVE-2025-37819 CVE-2025-37830 CVE-2025-37833 CVE-2025-37834 CVE-2025-37836 CVE-2025-37850 CVE-2025-37852 CVE-2025-37853 CVE-2025-37879 CVE-2025-37883 CVE-2025-37885 CVE-2025-37909 CVE-2025-37911 CVE-2025-37925 CVE-2025-37928 CVE-2025-37948 CVE-2025-37951 CVE-2025-37961 CVE-2025-37963 CVE-2025-37980 CVE-2025-37991 CVE-2025-37992 CVE-2025-38040 CVE-2025-38063 CVE-2025-38064 CVE-2025-38065 CVE-2025-38067 CVE-2025-38068 CVE-2025-38069 CVE-2025-38074 CVE-2025-38084 CVE-2025-38085 CVE-2025-38094 CVE-2025-38096 CVE-2025-38105 CVE-2025-38112 CVE-2025-38117 CVE-2025-38119 CVE-2025-38126 CVE-2025-38129 CVE-2025-38136 CVE-2025-38161 CVE-2025-38192 CVE-2025-38207 CVE-2025-38214 CVE-2025-38215 CVE-2025-38218 CVE-2025-38229 CVE-2025-38234 CVE-2025-38250 CVE-2025-38261 CVE-2025-38262 CVE-2025-38272 CVE-2025-38280 CVE-2025-38310 CVE-2025-38319 CVE-2025-38331 CVE-2025-38333 CVE-2025-38361 CVE-2025-38371 CVE-2025-38409 CVE-2025-38410 CVE-2025-38449 CVE-2025-38467 CVE-2025-38478 CVE-2025-38481 CVE-2025-38499 CVE-2025-38516 CVE-2025-38524 CVE-2025-38527 CVE-2025-38544 CVE-2025-38576 CVE-2025-38584 CVE-2025-38591 CVE-2025-38595 CVE-2025-38614 CVE-2025-38623 CVE-2025-38624 CVE-2025-38626 CVE-2025-38643 CVE-2025-38644 CVE-2025-38665 CVE-2025-38679 CVE-2025-38683 CVE-2025-38685 CVE-2025-38687 CVE-2025-38702 CVE-2025-38705 CVE-2025-38709 CVE-2025-38710 CVE-2025-38716 CVE-2025-38717 CVE-2025-38728 CVE-2025-38734 CVE-2025-39677 CVE-2025-39683 CVE-2025-39684 CVE-2025-39685 CVE-2025-39686 CVE-2025-39697 CVE-2025-39705 CVE-2025-39706 CVE-2025-39716 CVE-2025-39726 CVE-2025-39746 CVE-2025-39752 CVE-2025-39754 CVE-2025-39759 CVE-2025-39760 CVE-2025-39764 CVE-2025-39770 CVE-2025-39772 CVE-2025-39773 CVE-2025-39787 CVE-2025-39789 CVE-2025-39797 CVE-2025-39800 CVE-2025-39801 CVE-2025-39823 CVE-2025-39826 CVE-2025-39827 CVE-2025-39829 CVE-2025-39833 CVE-2025-39863 CVE-2025-39865 CVE-2025-39873 CVE-2025-39901 CVE-2025-39913 CVE-2025-39927 CVE-2025-39929 CVE-2025-39931 CVE-2025-39932 CVE-2025-39933 CVE-2025-39940 CVE-2025-39949 CVE-2025-39952 CVE-2025-39961 CVE-2025-39964 CVE-2025-39971 CVE-2025-40003 CVE-2025-40025 CVE-2025-40043 CVE-2025-40048 CVE-2025-40053 CVE-2025-40064 CVE-2025-40074 CVE-2025-40075 CVE-2025-40078 CVE-2025-40080 CVE-2025-40092 CVE-2025-40093 CVE-2025-40094 CVE-2025-40095 CVE-2025-40099 CVE-2025-40100 CVE-2025-40102 CVE-2025-40103 CVE-2025-40107 CVE-2025-40110 CVE-2025-40123 CVE-2025-40135 CVE-2025-40137 CVE-2025-40139 CVE-2025-40146 CVE-2025-40149 CVE-2025-40158 CVE-2025-40160 CVE-2025-40164 CVE-2025-40168 CVE-2025-40170 CVE-2025-40193 CVE-2025-40196 CVE-2025-40220 CVE-2025-40242 CVE-2025-40252 CVE-2025-40269 CVE-2025-40277 CVE-2025-40279 CVE-2025-40288 CVE-2025-40300 CVE-2025-40303 CVE-2025-40306 CVE-2025-40323 CVE-2025-40334 CVE-2025-40337 CVE-2025-40339 CVE-2025-40341 CVE-2025-40343 CVE-2025-40354 CVE-2025-40358 CVE-2025-4598 CVE-2025-62626 CVE-2025-68173 CVE-2025-68188 CVE-2025-68190 CVE-2025-68206 CVE-2025-68211 CVE-2025-68223 CVE-2025-68231 CVE-2025-68239 CVE-2025-68254 CVE-2025-68256 CVE-2025-68283 CVE-2025-68287 CVE-2025-68295 CVE-2025-68296 CVE-2025-68303 CVE-2025-68307 CVE-2025-68315 CVE-2025-68321 CVE-2025-68322 CVE-2025-68324 CVE-2025-68327 CVE-2025-68330 CVE-2025-68335 CVE-2025-68340 CVE-2025-68342 CVE-2025-68343 CVE-2025-68358 CVE-2025-68379 CVE-2025-68740 CVE-2025-68759 CVE-2025-68776 CVE-2025-68778 CVE-2025-68780 CVE-2025-68781 CVE-2025-68788 CVE-2025-68794 CVE-2025-68795 CVE-2025-68822 CVE-2025-71064 CVE-2025-71073 CVE-2025-71074 CVE-2025-71081 CVE-2025-71082 CVE-2025-71083 CVE-2025-71087 CVE-2025-71109 CVE-2025-71152 CVE-2025-71160 CVE-2025-71161 CVE-2025-71183 CVE-2025-71184 CVE-2025-71192 CVE-2025-71193 CVE-2025-71202 CVE-2025-71221 CVE-2025-71225 CVE-2025-71227 CVE-2026-22976 CVE-2026-22980 CVE-2026-23004 CVE-2026-23031 CVE-2026-23049 CVE-2026-23050 CVE-2026-23054 CVE-2026-23066 CVE-2026-23068 CVE-2026-23069 CVE-2026-23083 CVE-2026-23085 CVE-2026-23086 CVE-2026-23091 CVE-2026-23099 CVE-2026-23105 CVE-2026-23111 CVE-2026-23118 CVE-2026-23126 CVE-2026-23137 CVE-2026-23141 CVE-2026-23145 CVE-2026-23150 CVE-2026-23157 CVE-2026-23170 CVE-2026-23191 CVE-2026-23198 CVE-2026-23204 CVE-2026-23208 CVE-2026-23212 CVE-2026-23220 CVE-2026-23227 CVE-2026-23231 CVE-2026-23236 CVE-2026-23238), for more information check /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 408 tasks of which 0 didn't need to be rerun and all succeeded.

Summary: There were 3 WARNING messages shown.
```

### 6. Check Kernel's cve-check is ERROR (caused by python3-requests)
```
deby@5625c6a8d2a2:~/build$ bitbake linux-base -c cve_check
...<snip>...
ERROR: linux-base-4.19+gitAUTOINC+ef917a8bed-r0 do_cve_check: Error executing a python function in exec_python_func() autogenerated:

The stack trace of python calls that resulted in this exception/failure was:
File: 'exec_python_func() autogenerated', lineno: 2, function: <module>
     0001:
 *** 0002:kernel_cve_check(d)
     0003:
File: '/home/deby/poky/meta-debian/classes/kernel-cve-check.bbclass', lineno: 146, function: kernel_cve_check
     0142:    """
     0143:    Check cves by cip-kernel-sec
     0144:    """
     0145:    from bb.fetch2 import runfetchcmd
 *** 0146:    import requests
     0147:    import bb.process
     0148:    import yaml
     0149:    import os
     0150:    import tempfile
Exception: ModuleNotFoundError: No module named 'requests'

ERROR: linux-base-4.19+gitAUTOINC+ef917a8bed-r0 do_cve_check: No module named 'requests'
ERROR: linux-base-4.19+gitAUTOINC+ef917a8bed-r0 do_cve_check: Function failed: kernel_cve_check
ERROR: Logfile of failure stored in: /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/temp/log.do_cve_check.341230
ERROR: Task (/home/deby/poky/meta-debian/recipes-kernel/linux/linux-base_git.bb:do_cve_check) failed with exit code '1'
NOTE: Tasks Summary: Attempted 408 tasks of which 406 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /home/deby/poky/meta-debian/recipes-kernel/linux/linux-base_git.bb:do_cve_check
Summary: There were 2 WARNING messages shown.
Summary: There were 3 ERROR messages shown, returning a non-zero exit code.
```

### 8. Check Kernel's cve-check is ERROR (caused by python3-html5lib)
This PR fix resulted in the display of the ERROR message.
```
deby@5625c6a8d2a2:~/build$ bitbake linux-base -c cve_check
...<snip>...
ERROR: linux-base-4.19+gitAUTOINC+ef917a8bed-r0 do_cve_check: Failed to run report_affected.py: Fetcher failure: Fetch command export PSEUDO_DISABLED=1; unset _PYTHON_SYSCONFIGDATA_NAME; export NO_PROXY="lab-slave-0,master1,healthcheck,local,localhost,127.0.0.0/8"; export https_proxy="http://<PROXY-SERVER>:<PROXY-PORT>"; export HTTPS_PROXY="http://<PROXY-SERVER>:<PROXY-PORT>"; export http_proxy="http://<PROXY-SERVER>:<PROXY-PORT>"; export HTTP_PROXY="http://<PROXY-SERVER>:<PROXY-PORT>"; export PATH="/home/deby/build/tmp/sysroots-uninative/x86_64-linux/usr/bin:/home/deby/poky/scripts:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/usr/bin/aarch64-deby-linux:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot/usr/bin/crossscripts:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/usr/sbin:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/usr/bin:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/sbin:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/bin:/home/deby/poky/bitbake/bin:/home/deby/build/tmp/hosttools"; export HOME="/home/deby"; PYTHONPATH='/home/deby/poky/meta-debian/lib:/home/deby/poky/meta-poky/lib:/home/deby/build/lib:/home/deby/poky/meta/lib:/home/deby/poky/bitbake:/home/deby/poky/bitbake/lib:/home/deby/poky/bitbake/bin:/usr/lib/python37.zip:/usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages' SSL_CERT_FILE='/etc/ssl/certs/ca-certificates.crt' python3 scripts/report_affected.py --include-ignored --include-fixed --output-format=yaml --output-filename=/tmp/tmpqfbxhog5 --remote-name cip:origin --git-repo /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/git v4.19.325-cip130 failed with exit code 1, output:
Traceback (most recent call last):
  File "scripts/report_affected.py", line 18, in <module>
    import kernel_sec.branch
  File "/home/deby/downloads/CVE_CHECK/KERNEL/cip-kernel-sec/scripts/kernel_sec/branch.py", line 18, in <module>
    import html5lib
ModuleNotFoundError: No module named 'html5lib'

WARNING: linux-base-4.19+gitAUTOINC+ef917a8bed-r0 do_cve_check: Found unpatched CVE (CVE-1999-0524 CVE-1999-0656 CVE-2006-2932 CVE-2007-2764 CVE-2007-4998 CVE-2015-7312 CVE-2016-3699 CVE-2017-1000377 CVE-2017-6264 CVE-2019-14899 CVE-2020-36766 CVE-2021-3923 CVE-2023-1476 CVE-2023-3079), for more information check /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 408 tasks of which 406 didn't need to be rerun and all succeeded.

Summary: There were 3 WARNING messages shown.
Summary: There was 1 ERROR message shown, returning a non-zero exit code.
```

### 10. Check Kernel's cve-check is OK
```
deby@5625c6a8d2a2:~/build$ bitbake linux-base -c cve_check
...<snip>...
NOTE: Tasks Summary: Attempted 408 tasks of which 406 didn't need to be rerun and all succeeded.

Summary: There were 3 WARNING messages shown.
```

### For reference, test results before this PR
WARNING was displayed if "python3-html5lib" is not installed.
```
deby@5625c6a8d2a2:~/build$ bitbake linux-base -c cve_check
...<snip>...
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:d53b770baa9d76ae15628072fe1001843c0ef50f"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 0 Found 0 Missed 0 Current 42 (0% match, 100% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
WARNING: linux-base-4.19+gitAUTOINC+ef917a8bed-r0 do_cve_check: Failed to run report_affected.py: Fetcher failure: Fetch command export PSEUDO_DISABLED=1; unset _PYTHON_SYSCONFIGDATA_NAME; export NO_PROXY="lab-slave-0,master1,healthcheck,local,localhost,127.0.0.0/8"; export https_proxy="http://<PROXY-SERVER>:<PROXY-PORT>"; export HTTPS_PROXY="http://<PROXY-SERVER>:<PROXY-PORT>"; export http_proxy="http://<PROXY-SERVER>:<PROXY-PORT>"; export HTTP_PROXY="http://<PROXY-SERVER>:<PROXY-PORT>"; export PATH="/home/deby/build/tmp/sysroots-uninative/x86_64-linux/usr/bin:/home/deby/poky/scripts:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/usr/bin/aarch64-deby-linux:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot/usr/bin/crossscripts:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/usr/sbin:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/usr/bin:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/sbin:/home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/recipe-sysroot-native/bin:/home/deby/poky/bitbake/bin:/home/deby/build/tmp/hosttools"; export HOME="/home/deby"; PYTHONPATH='/home/deby/poky/meta-debian/lib:/home/deby/poky/meta-poky/lib:/home/deby/build/lib:/home/deby/poky/meta/lib:/home/deby/poky/bitbake:/home/deby/poky/bitbake/lib:/home/deby/poky/bitbake/bin:/usr/lib/python37.zip:/usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages' SSL_CERT_FILE='/etc/ssl/certs/ca-certificates.crt' python3 scripts/report_affected.py --include-ignored --include-fixed --output-format=yaml --output-filename=/tmp/tmpmj2hcfu0 --remote-name cip:origin --git-repo /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/git v4.19.325-cip130 failed with exit code 1, output:
Traceback (most recent call last):
  File "scripts/report_affected.py", line 18, in <module>
    import kernel_sec.branch
  File "/home/deby/downloads/CVE_CHECK/KERNEL/cip-kernel-sec/scripts/kernel_sec/branch.py", line 18, in <module>
    import html5lib
ModuleNotFoundError: No module named 'html5lib'

WARNING: linux-base-4.19+gitAUTOINC+ef917a8bed-r0 do_cve_check: Found unpatched CVE (CVE-1999-0524 CVE-1999-0656 CVE-2006-2932 CVE-2007-2764 CVE-2007-4998 CVE-2015-7312 CVE-2016-3699 CVE-2017-1000377 CVE-2017-6264 CVE-2019-14899 CVE-2020-36766 CVE-2021-3923 CVE-2023-1476 CVE-2023-3079), for more information check /home/deby/build/tmp/work/qemuarm64-deby-linux/linux-base/4.19+gitAUTOINC+ef917a8bed-r0/temp/cve.log
NOTE: Tasks Summary: Attempted 408 tasks of which 406 didn't need to be rerun and all succeeded.

Summary: There were 4 WARNING messages shown.
```

