### PR TITLE
Multiple recipes: Remove misplaced library files from ptest packages

### DIFF
--- a/recipes-debian/libffi/libffi_debian.bb
+++ b/recipes-debian/libffi/libffi_debian.bb
@@ -86,6 +86,10 @@ do_install_ptest() {
     # Remove rpath from test binaries
     find ${D}${PTEST_PATH}/testsuite/ -name '*.exe' \
         -exec patchelf --remove-rpath {} \;
+
+    # Remove library files from ptest package
+    find ${D}${PTEST_PATH} \( -name '*.so' -o -name '*.so.*' \) \
+        -exec rm -f {} \;
 }
 
 DEPENDS += "${@bb.utils.contains('PTEST_ENABLED', '1', 'dejagnu-native patchelf-native', '', d)}"

--- a/recipes-debian/libpng/libpng_debian.bb
+++ b/recipes-debian/libpng/libpng_debian.bb
@@ -74,6 +74,10 @@ do_install_ptest() {
         -e 's|^abs_srcdir =.*|abs_srcdir = .|g' \
         -e 's|^abs_top_srcdir =.*|abs_top_srcdir = .|g' \
         ${D}${PTEST_PATH}/Makefile
+
+    # Remove library files from ptest package
+    find ${D}${PTEST_PATH} \( -name '*.so' -o -name '*.so.*' \) \
+        -exec rm -f {} \;
 }
 
 RDEPENDS_${PN}-ptest += "make gawk"

--- a/recipes-debian/xorg-lib/libxau_debian.bb
+++ b/recipes-debian/xorg-lib/libxau_debian.bb
@@ -50,6 +50,10 @@ do_install_ptest() {
     install -m 644 ${B}/*.la ${D}${PTEST_PATH}
     install -m 644 ${B}/*.o ${D}${PTEST_PATH}
     install -m 755 ${B}/.libs/* ${D}${PTEST_PATH}
+
+    # Remove library files from ptest package
+    find ${D}${PTEST_PATH} \( -name '*.so' -o -name '*.so.*' \) \
+        -exec rm -f {} \;
 }
 
 RDEPENDS_${PN}-ptest += "make gawk"

--- a/recipes-debian/xorg-lib/pixman_debian.bb
+++ b/recipes-debian/xorg-lib/pixman_debian.bb
@@ -77,6 +77,10 @@ do_install_ptest() {
             -e 's|^top_srcdir =.*$|top_srcdir = ..|g' \
             ${D}${PTEST_PATH}/$d/Makefile
     done
+
+    # Remove library files from ptest package
+    find ${D}${PTEST_PATH} \( -name '*.so' -o -name '*.so.*' \) \
+        -exec rm -f {} \;
 }
 
 RDEPENDS_${PN}-ptest += "make gawk"


### PR DESCRIPTION
# Purpose of the Pull Request
Due to the automatic shared library dependency feature, having library files in ptest subpackages triggers an unintended dependency, pulling those packages into the image.

Remove library files from the affected ptest packages in the following recipes, as they should belong to their respective main packages:
- recipes-debian/libffi/libffi_debian.bb
- recipes-debian/libpng/libpng_debian.bb
- recipes-debian/xorg-lib/libxau_debian.bb
- recipes-debian/xorg-lib/pixman_debian.bb

# Test
1. Check ptest is not included
2. Check ptest works correctly

## Test steps

### 1. Check ptest is not included

1. Startup the Docker environment

   ```
   $ cd meta-debian/docker
   $ make start
   ```

2. Setup build environment

   ```
   deby@<container-id>:~$ export TEMPLATECONF=meta-debian/conf
   deby@<container-id>:~$ source ./poky/oe-init-build-env
   ```

3. Setting local.conf
   Add following line into conf/local.conf.
   ```
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   IMAGE_INSTALL_append = " python3"
   ```

4. Build image
   ```
   $ bitbake core-image-minimal
   ```

5. Check ptest is not included
   Check that the ptest package is not in the generated manifest.
   ```
   $ grep ptest ./tmp/deploy/images/qemuarm64/core-image-minimal-qemuarm64.manifest
   ```

### 2. Check ptest works correctly

1. Prepare environment variables

   ```
   export TEST_PACKAGES="libffi libpng pixman libxau"
   export TEST_DISTROS="deby"
   export TEST_MACHINES="qemuarm64"
   export COMPOSE_HTTP_TIMEOUT=7200
   export PTEST_RUNNER_TIMEOUT=7200
   export QEMU_PARAMS="-smp 2 -m 8192"
   export IMAGE_ROOTFS_EXTRA_SPACE=1048576
   ```

2. Run ptest on docker of meta-debian

   ```
   $ cd ./meta-debian/docker/
   $ make qemu_ptest
   ```

3. Check ptest works correctly

Check that the results are identical before and after the fix to ensure ptest functions as expected.

## Test result
### 1. Check ptest is not included

Confirmed that ptest is no longer included in this PR.

**Results after this PR**
```
deby@e1768d093b7b:~/build$ bitbake core-image-minimal
Parsing recipes: 100% |#################################################################################################| Time: 0:00:07
Parsing of 1044 .bb files complete (0 cached, 1044 parsed). 1828 targets, 74 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "remove-library-files-from-ptest-package:72f3f2601a66c36781af51749251b5929602fa9e"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 842 Found 0 Missed 842 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2965 tasks of which 5 didn't need to be rerun and all succeeded.
```
```
deby@e1768d093b7b:~/build$ grep ptest ./tmp/deploy/images/qemuarm64/core-image-minimal-qemuarm64.manifest -c
0
```

**Results before this PR**

The ptest package was included before this PR.

```
deby@6f9ba800bc98:~/build$ bitbake core-image-minimal
Parsing recipes: 100% |#################################################################################################| Time: 0:00:05
Parsing of 1044 .bb files complete (0 cached, 1044 parsed). 1828 targets, 74 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:3866d66861f63662603cf9d8338dcd317609bcf5"
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 842 Found 0 Missed 842 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2965 tasks of which 5 didn't need to be rerun and all succeeded.
```

```
deby@6f9ba800bc98:~/build$ grep ptest ./tmp/deploy/images/qemuarm64/core-image-minimal-qemuarm64.manifest
libffi-ptest aarch64 3.2.1-r0
ptest-runner aarch64 2.3.1+git0+63d097cc46-r0
```


### 2. Check ptest works correctly

Confirmed ptest results remain the same before and after the PR.

**Results after this PR**
```
meta-debian/docker$ make qemu_ptest
docker-compose run --rm qemu_ptest
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
Creating docker_qemu_ptest_run ... done
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.
You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.
The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation
For more information about OpenEmbedded see their website:
    http://www.openembedded.org/
NOTE: These packages will be tested: libffi libpng pixman libxau
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: Set IMAGE_ROOTFS_EXTRA_SPACE to 1048576 KB.
Parsing recipes: 100% |#################################################################################################| Time: 0:00:08
Parsing of 1044 .bb files complete (0 cached, 1044 parsed). 1828 targets, 68 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "remove-library-files-from-ptest-package:72f3f2601a66c36781af51749251b5929602fa9e"
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 860 Found 0 Missed 860 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3017 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams="-smp 2 -m 8192"`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (5s / 60s)
NOTE: Waiting for SSH to be ready... (10s / 60s)
stdin: is not a tty
Running ptest for libffi ...
libffi: PASS/SKIP/FAIL = 1870/0/0
Running ptest for libpng ...
libpng: PASS/SKIP/FAIL = 33/0/0
Running ptest for pixman ...
pixman: PASS/SKIP/FAIL = 33/0/0
Running ptest for libxau ...
libxau: PASS/SKIP/FAIL = 1/0/0
stdin: is not a tty
```

**Results before this PR**
```
meta-debian/docker$ make qemu_ptest
docker-compose run --rm qemu_ptest
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
Creating docker_qemu_ptest_run ... done
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.
You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.
The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation
For more information about OpenEmbedded see their website:
    http://www.openembedded.org/
NOTE: These packages will be tested: libffi libpng pixman libxau
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
NOTE: Set IMAGE_ROOTFS_EXTRA_SPACE to 1048576 KB.
Parsing recipes: 100% |#################################################################################################| Time: 0:00:07
Parsing of 1044 .bb files complete (0 cached, 1044 parsed). 1828 targets, 68 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies
Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:3866d66861f63662603cf9d8338dcd317609bcf5"
Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 860 Found 0 Missed 860 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 3017 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams="-smp 2 -m 8192"`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (5s / 60s)
NOTE: Waiting for SSH to be ready... (10s / 60s)
stdin: is not a tty
Running ptest for libffi ...
libffi: PASS/SKIP/FAIL = 1870/0/0
Running ptest for libpng ...
libpng: PASS/SKIP/FAIL = 33/0/0
Running ptest for pixman ...
pixman: PASS/SKIP/FAIL = 33/0/0
Running ptest for libxau ...
libxau: PASS/SKIP/FAIL = 1/0/0
stdin: is not a tty
```
