### PR TITLE
libffi: Improve ptest to package only minimum necessary files

### DIFF
--- a/recipes-debian/libffi/libffi/run-ptest
+++ b/recipes-debian/libffi/libffi/run-ptest
@@ -1,2 +1,11 @@
 #!/bin/sh
-make -k -C testsuite check RUNTESTFLAGS="-a"
+cd testsuite
+
+LIB_DIR="../.libs"
+mkdir -p "${LIB_DIR}"
+LINK_FILE="${LIB_DIR}/libffi.so"
+if ! [ -L "${LINK_FILE}" ]; then
+    ln -s /usr/lib/libffi.so.*.*.* "${LINK_FILE}"
+fi
+runtest --tool libffi --srcdir ./ -a
+rm -f "${LINK_FILE}"

--- a/recipes-debian/libffi/libffi_debian.bb
+++ b/recipes-debian/libffi/libffi_debian.bb
@@ -30,70 +30,31 @@ inherit autotools texinfo ptest
 FILES_${PN}-dev += "${libdir}/libffi-${PV}"
 
 do_compile_ptest() {
-    # Prevent execution of test binaries on host environment
-    sed -i \
-        -e 's/dg-do run/dg-do link/g' \
-        ${S}/testsuite/libffi.call/*
-
-    # Compile test binaries
-    oe_runmake -k -C testsuite check RUNTESTFLAGS="-a"
-
-    # Restore the previous change to make sure tests will be executed
-    # on target environment
-    sed -i \
-        -e 's/dg-do link/dg-do run/g' \
-        ${S}/testsuite/libffi.call/*
+    # Compile site.exp file
+    oe_runmake -C testsuite site.exp
 }
 
 do_install_ptest() {
+    cp -r --dereference ${B}/include/ ${D}${PTEST_PATH}/
+    rm ${D}${PTEST_PATH}/include/Makefile*
     cp -r ${S}/testsuite/ ${D}${PTEST_PATH}/
-    cp -r ${B}/* ${D}${PTEST_PATH}/
-    cp -r ${B}/.libs/* ${D}${PTEST_PATH}/
-
-    # Replace CC and CXX with true command to prevent compilation on target
-    # environment (instead, do nothing)
-    sed -i \
-        -e 's|^set CC_FOR_TARGET .*|set CC_FOR_TARGET "true"|g' \
-        -e 's|^set CXX_FOR_TARGET .*|set CXX_FOR_TARGET "true"|g' \
-        ${D}${PTEST_PATH}/testsuite/site.exp
+    cp -r ${B}/testsuite/ ${D}${PTEST_PATH}/
+    rm ${D}${PTEST_PATH}/testsuite/Makefile*
+    cp -r ${B}/config.status ${D}${PTEST_PATH}/
+    cp -r ${B}/fficonfig.h ${D}${PTEST_PATH}/
+    cp -r ${B}/local.exp ${D}${PTEST_PATH}/
 
     sed -i \
         -e 's|^set srcdir .*|set srcdir "."|g' \
         -e 's|^set objdir .*|set objdir "."|g' \
+        -e '/^set build_alias/s/^/#/' \
+        -e '/^set build_triplet/s/^/#/' \
+        -e '/^set CC_FOR_TARGET/s/^/#/' \
+        -e '/^set CXX_FOR_TARGET/s/^/#/' \
         ${D}${PTEST_PATH}/testsuite/site.exp
-
-    sed -i \
-        -e 's|^VPATH =.*$|VPATH = .|g' \
-        -e 's|^Makefile:.*$|Makefile:|g' \
-        -e 's|^srcdir =.*|srcdir = .|g' \
-        -e 's|^top_srcdir =.*|top_srcdir = .|g' \
-        -e 's|^abs_srcdir =.*|abs_srcdir = .|g' \
-        -e 's|^abs_top_srcdir =.*|abs_top_srcdir = .|g' \
-        -e "s|${BPN}-${PV}/config.guess|./config.guess|g" \
-        ${D}${PTEST_PATH}/Makefile
-
-    for d in include testsuite; do
-        sed -i \
-            -e 's|^VPATH =.*$|VPATH = .|g' \
-            -e 's|^Makefile:.*$|Makefile:|g' \
-            -e 's|^srcdir =.*|srcdir = .|g' \
-            -e 's|^top_srcdir =.*|top_srcdir = ..|g' \
-            -e 's|^abs_srcdir =.*|abs_srcdir = .|g' \
-            -e 's|^abs_top_srcdir =.*|abs_top_srcdir = ..|g' \
-            ${D}${PTEST_PATH}/$d/Makefile
-    done
-
-    # Remove rpath from test binaries
-    find ${D}${PTEST_PATH}/testsuite/ -name '*.exe' \
-        -exec patchelf --remove-rpath {} \;
-
-    # Remove library files from ptest package
-    find ${D}${PTEST_PATH} \( -name '*.so' -o -name '*.so.*' \) \
-        -exec rm -f {} \;
 }
 
-DEPENDS += "${@bb.utils.contains('PTEST_ENABLED', '1', 'dejagnu-native patchelf-native', '', d)}"
-RDEPENDS_${PN}-ptest += "bash dejagnu make"
+RDEPENDS_${PN}-ptest += "bash dejagnu gcc-symlinks g++-symlinks binutils"
 
 # Doesn't compile in MIPS16e mode due to use of hand-written
 # assembly


### PR DESCRIPTION
# Purpose of the Pull Request

The libffi-ptest test suites include compilation steps.

Previously, this compilation was performed on the build host.
This commit updates the process to compile directly on the target board during
test execution.

By shifting compilation to the target, the files included in the libffi-ptest
package are now reduced to the absolute minimum necessary.

# Test
1. Run libffi-ptest on docker
2. Check libffi-ptest packaged files

## How to test
### Run libffi-ptest on docker
1. Prepare environment variables
   ```
   export TEST_PACKAGES="libffi"
   export TEST_DISTROS="deby"
   export TEST_MACHINES="qemuarm64"
   export COMPOSE_HTTP_TIMEOUT=7200
   export PTEST_RUNNER_TIMEOUT=7200
   ```

2. Run libffi-ptest
   ```
   $ cd meta-debian/docker
   $ make qemu_ptest
   ```

3. Check ptest logs
   ```
   $ head ../tests/logs/deby/qemuarm64/libffi.ptest.log
   $ tail ../tests/logs/deby/qemuarm64/libffi.ptest.log
   ```

### Check libffi-ptest packaged files
1. Start build environment on docker
   ```
   $ cd meta-debian/docker
   $ make start
   ```

2. Setup build environment
   ```
   export TEMPLATECONF=meta-debian/conf
   source ./poky/oe-init-build-env
   ```

3. local.conf settings
   ```
   $ cat << EOS >> conf/local.conf
   DISTRO = "deby"
   MACHINE = "qemuarm64"
   IMAGE_INSTALL_append = " libffi-ptest"
   EOS
   ```

4. Build
   ```
   $ bitbake core-image-minimal
   ```

5. Check libffi-ptest packaged files

   ```
   $ cd ./tmp/work/aarch64-deby-linux/libffi/3.2.1-r0/packages-split/libffi-ptest/
   $ find . -type f | wc -l
   $ find . -type f
   ``` 

## Test result
### Run libffi-ptest on docker

The ptest results were the same before and after this MR.

- After this MR: `libffi: PASS/SKIP/FAIL = 1870/0/0`
- Before this MR: `libffi: PASS/SKIP/FAIL = 1870/0/0`

The DURATION has also increased from `137`s to `981`s because the code is now compiled directly on the target board during test execution.

#### After this MR logs
```
meta-debian/docker$ make qemu_ptest 
docker-compose run --rm qemu_ptest
WARNING: The QEMU_PARAMS variable is not set. Defaulting to a blank string.
WARNING: The IMAGE_ROOTFS_EXTRA_SPACE variable is not set. Defaulting to a blank string.
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
Creating docker_qemu_ptest_run ... done
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: libffi
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
Parsing recipes: 100% |#################################################################################################| Time: 0:00:04
Parsing of 1044 .bb files complete (0 cached, 1044 parsed). 1828 targets, 68 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "improve-libffi-ptest-to-warrior:22a24b98361f7f7c5861b0ecd8842ee6c9c4e963"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:00
Sstate summary: Wanted 844 Found 0 Missed 844 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2957 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams=""`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (5s / 60s)
NOTE: Waiting for SSH to be ready... (11s / 60s)
stdin: is not a tty
Running ptest for libffi ...
libffi: PASS/SKIP/FAIL = 1870/0/0
stdin: is not a tty
```
```
meta-debian/docker$ head -n 20 ../tests/logs/deby/qemuarm64/libffi.ptest.log 
START: ptest-runner
ERROR: Unable to detach from controlling tty, Inappropriate ioctl for device
2026-06-08T06:30
BEGIN: /usr/lib/libffi/ptest
WARNING: Couldn't find the global config file.
Using ./lib/libffi.exp as tool init file.
Test run by root on Mon Jun  8 06:30:32 2026
Native configuration is aarch64-deby-linux-gnu

		=== libffi tests ===

Schedule of variations:
    unix

Running target unix
Using /usr/share/dejagnu/baseboards/unix.exp as board description file for target.
Using /usr/share/dejagnu/config/unix.exp as generic interface file for target.
Using .//config/default.exp as tool-and-target-specific interface file.
Running ./libffi.call/call.exp ...
PASS: libffi.call/closure_fn0.c -W -Wall -Wno-psabi -O0 (test for excess errors)
```
```
after/meta-debian/docker$ tail -n 10 ../tests/logs/deby/qemuarm64/libffi.ptest.log 
PASS: libffi.call/va_struct3.c -W -Wall -Wno-psabi -O2 -fomit-frame-pointer execution test
PASS: libffi.call/va_struct3.c -W -Wall -Wno-psabi -O2 -fomit-frame-pointer output pattern test

		=== libffi Summary ===

# of expected passes		1870
DURATION: 981
END: /usr/lib/libffi/ptest
2026-06-08T06:46
STOP: ptest-runner
```

#### Before this MR logs
```
meta-debian/docker$ make qemu_ptest 
docker-compose run --rm qemu_ptest
WARNING: The QEMU_PARAMS variable is not set. Defaulting to a blank string.
WARNING: The IMAGE_ROOTFS_EXTRA_SPACE variable is not set. Defaulting to a blank string.
WARNING: The no_proxy variable is not set. Defaulting to a blank string.
WARNING: The TEST_DISTRO_FEATURES variable is not set. Defaulting to a blank string.
Creating docker_qemu_ptest_run ... done
mkstemp: No such file or directory
NOTE: Setup build directory.
You had no conf/local.conf file. This configuration file has therefore been
created for you with some default values. You may wish to edit it to, for
example, select a different MACHINE (target hardware). See conf/local.conf
for more information as common configuration options are commented.

You had no conf/bblayers.conf file. This configuration file has therefore been
created for you with some default values. To add additional metadata layers
into your configuration please add entries to conf/bblayers.conf.

The Yocto Project has extensive documentation about OE including a reference
manual which can be found at:
    http://yoctoproject.org/documentation

For more information about OpenEmbedded see their website:
    http://www.openembedded.org/

NOTE: These packages will be tested: libffi
NOTE: Testing distro deby ...
NOTE: Testing machine qemuarm64 ...
Parsing recipes: 100% |#################################################################################################| Time: 0:00:08
Parsing of 1044 .bb files complete (0 cached, 1044 parsed). 1828 targets, 68 skipped, 0 masked, 0 errors.
NOTE: Resolving any missing task queue dependencies

Build Configuration:
BB_VERSION           = "1.42.0"
BUILD_SYS            = "x86_64-linux"
NATIVELSBSTRING      = "debian-10"
TARGET_SYS           = "aarch64-deby-linux"
MACHINE              = "qemuarm64"
DISTRO               = "deby"
DISTRO_VERSION       = "10.0"
TUNE_FEATURES        = "aarch64 armv8a crc"
TARGET_FPU           = ""
meta                 
meta-poky            = "warrior:d4b57c68b22027c2bedff335dee06af963e4f8a8"
meta-debian          = "warrior:9d2b970bd7708a2d8c1cf848362ef44826bf5b59"

Initialising tasks: 100% |##############################################################################################| Time: 0:00:01
Sstate summary: Wanted 848 Found 0 Missed 848 Current 0 (0% match, 0% complete)
NOTE: Executing SetScene Tasks
NOTE: Executing RunQueue Tasks
NOTE: Tasks Summary: Attempted 2979 tasks of which 5 didn't need to be rerun and all succeeded.
NOTE: Run command: `runqemu qemuarm64 nographic slirp qemuparams=""`
nohup: redirecting stderr to stdout
NOTE: Waiting for SSH to be ready... (5s / 60s)
NOTE: Waiting for SSH to be ready... (10s / 60s)
stdin: is not a tty
Running ptest for libffi ...
libffi: PASS/SKIP/FAIL = 1870/0/0
stdin: is not a tty
```
```
meta-debian/docker$ head -n 37 ../tests/logs/deby/qemuarm64/libffi.ptest.log 
START: ptest-runner
ERROR: Unable to detach from controlling tty, Inappropriate ioctl for device
2026-06-08T06:30
BEGIN: /usr/lib/libffi/ptest
make: Entering directory '/usr/lib/libffi/ptest/testsuite'
make  check-DEJAGNU
make[1]: Entering directory '/usr/lib/libffi/ptest/testsuite'
srcdir='.'; export srcdir; \
EXPECT=expect; export EXPECT; \
if /bin/bash -c "runtest --version" > /dev/null 2>&1; then \
  exit_status=0; l='libffi'; for tool in $l; do \
    if runtest --tool $tool --srcdir $srcdir  -a; \
    then :; else exit_status=1; fi; \
  done; \
else echo "WARNING: could not find 'runtest'" 1>&2; :;\
fi; \
exit $exit_status
WARNING: Couldn't find the global config file.
Using ./lib/libffi.exp as tool init file.
Test run by root on Mon Jun  8 06:30:36 2026
Target is aarch64-deby-linux-gnu
Host   is aarch64-deby-linux-gnu
Build  is x86_64-pc-linux-gnu

		=== libffi tests ===

Schedule of variations:
    unix

Running target unix
Using /usr/share/dejagnu/baseboards/unix.exp as board description file for target.
Using /usr/share/dejagnu/config/unix.exp as generic interface file for target.
Using ./config/default.exp as tool-and-target-specific interface file.
WARNING: Assuming target board is the local machine (which is probably wrong).
You may need to set your DEJAGNU environment variable.
Running ./libffi.call/call.exp ...
PASS: libffi.call/closure_fn0.c -W -Wall -Wno-psabi -O0 (test for excess errors)
```
```
meta-debian/docker$ tail -n 12 ../tests/logs/deby/qemuarm64/libffi.ptest.log 
PASS: libffi.call/va_struct3.c -W -Wall -Wno-psabi -O2 -fomit-frame-pointer execution test
PASS: libffi.call/va_struct3.c -W -Wall -Wno-psabi -O2 -fomit-frame-pointer output pattern test

		=== libffi Summary ===

# of expected passes		1870
make[1]: Leaving directory '/usr/lib/libffi/ptest/testsuite'
make: Leaving directory '/usr/lib/libffi/ptest/testsuite'
DURATION: 137
END: /usr/lib/libffi/ptest
2026-06-08T06:32
STOP: ptest-runner
```

### Check libffi-ptest packaged files

The number of files has been reduced to the bare minimum necessary for testing.

Number of files included in the libffi-ptest package:
- After this MR: `150`
- Before this MR: `318`

#### After this MR logs
```
deby@1dcb044c4249:~/build/tmp/work/aarch64-deby-linux/libffi/3.2.1-r0/packages-split/libffi-ptest$ find . -type f | wc -l
150
```
```
deby@1dcb044c4249:~/build/tmp/work/aarch64-deby-linux/libffi/3.2.1-r0/packages-split/libffi-ptest$ find . -type f
./usr/lib/libffi/ptest/fficonfig.h
./usr/lib/libffi/ptest/config.status
./usr/lib/libffi/ptest/run-ptest
./usr/lib/libffi/ptest/local.exp
./usr/lib/libffi/ptest/testsuite/config/default.exp
./usr/lib/libffi/ptest/testsuite/lib/wrapper.exp
./usr/lib/libffi/ptest/testsuite/lib/libffi.exp
./usr/lib/libffi/ptest/testsuite/lib/target-libpath.exp
./usr/lib/libffi/ptest/testsuite/site.exp
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_20byte1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_longdouble_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_schar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn5.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_sint16.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct8.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_3byte1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_uchar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_3_1byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/err_bad_abi.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_loc_fn0.c
./usr/lib/libffi/ptest/testsuite/libffi.call/unwindtest_ffi_call.cc
./usr/lib/libffi/ptest/testsuite/libffi.call/stret_medium2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_ushortchar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/err_bad_typedef.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_dbl2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_6byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct9.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_7_1_byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn6.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/stret_large2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_simple.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_19byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_double.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_uint_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_12byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/va_struct1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/stret_medium.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_longdouble.c
./usr/lib/libffi/ptest/testsuite/libffi.call/ffitest.h
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_schar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct7.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_uint.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_5_1_byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_9byte2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/va_struct2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_sshort.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct7.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_ushort.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_24byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct6.c
./usr/lib/libffi/ptest/testsuite/libffi.call/problem1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_4byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_pointer.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_dbl1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_dbls_struct.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_2byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/uninitialized.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_1_1byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_sint64.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_ul.c
./usr/lib/libffi/ptest/testsuite/libffi.call/huge_struct.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_double_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct11.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_ll.c
./usr/lib/libffi/ptest/testsuite/libffi.call/testclosure.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_sint.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_fl.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_ll1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_fl1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_longdouble_split2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/va_struct3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/call.exp
./usr/lib/libffi/ptest/testsuite/libffi.call/return_uc.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_longdouble_split.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_uint16.c
./usr/lib/libffi/ptest/testsuite/libffi.call/negint.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn0.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_ushort_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_fl3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/unwindtest.cc
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_6_1_byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn4.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float4.c
./usr/lib/libffi/ptest/testsuite/libffi.call/many2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_pointer_stack.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_uchar_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct4.c
./usr/lib/libffi/ptest/testsuite/libffi.call/many.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct8.c
./usr/lib/libffi/ptest/testsuite/libffi.call/va_1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_3byte2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_sl.c
./usr/lib/libffi/ptest/testsuite/libffi.call/strlen3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_double.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_ldl.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_8byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_7byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_dbl.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_ushort.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_20byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_sshort.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_4_1byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_18byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_sc.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_ulong_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_sint32.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_pointer.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_ulonglong.c
./usr/lib/libffi/ptest/testsuite/libffi.call/strlen2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct4.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_uint32.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct10.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_float.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct5.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_5byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_float.c
./usr/lib/libffi/ptest/testsuite/libffi.call/strlen.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_sshortchar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/pyobjc-tc.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_uchar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/stret_large.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct6.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_9byte1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_longdouble.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_uint64.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_64byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct5.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_struct_va1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct9.c
./usr/lib/libffi/ptest/testsuite/libffi.call/promotion.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_fl2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_16byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/strlen4.c
./usr/lib/libffi/ptest/include/ffi.h
./usr/lib/libffi/ptest/include/ffitarget.h
```

#### Before this MR logs
```
deby@6c850f7f5d88:~/build/tmp/work/aarch64-deby-linux/libffi/3.2.1-r0/packages-split/libffi-ptest$ find . -type f | wc -l
318
```
```
deby@6c850f7f5d88:~/build/tmp/work/aarch64-deby-linux/libffi/3.2.1-r0/packages-split/libffi-ptest$ find . -type f
./usr/lib/libffi/ptest/aarch64-deby-linux-libtool
./usr/lib/libffi/ptest/fficonfig.h
./usr/lib/libffi/ptest/config.status
./usr/lib/libffi/ptest/libffi.pc
./usr/lib/libffi/ptest/config.log
./usr/lib/libffi/ptest/run-ptest
./usr/lib/libffi/ptest/libffi.lai
./usr/lib/libffi/ptest/stamp-h1
./usr/lib/libffi/ptest/local.exp
./usr/lib/libffi/ptest/man/Makefile
./usr/lib/libffi/ptest/testsuite/cls_dbls_struct.exe
./usr/lib/libffi/ptest/testsuite/cls_12byte.exe
./usr/lib/libffi/ptest/testsuite/cls_align_longdouble.exe
./usr/lib/libffi/ptest/testsuite/cls_longdouble_va.exe
./usr/lib/libffi/ptest/testsuite/nested_struct11.exe
./usr/lib/libffi/ptest/testsuite/stret_large.exe
./usr/lib/libffi/ptest/testsuite/cls_ushort_va.exe
./usr/lib/libffi/ptest/testsuite/cls_5byte.exe
./usr/lib/libffi/ptest/testsuite/config/default.exp
./usr/lib/libffi/ptest/testsuite/cls_ushort.exe
./usr/lib/libffi/ptest/testsuite/nested_struct6.exe
./usr/lib/libffi/ptest/testsuite/cls_ulong_va.exe
./usr/lib/libffi/ptest/testsuite/cls_double.exe
./usr/lib/libffi/ptest/testsuite/nested_struct10.exe
./usr/lib/libffi/ptest/testsuite/uninitialized.exe
./usr/lib/libffi/ptest/testsuite/struct2.exe
./usr/lib/libffi/ptest/testsuite/cls_4_1byte.exe
./usr/lib/libffi/ptest/testsuite/libffi.log
./usr/lib/libffi/ptest/testsuite/cls_1_1byte.exe
./usr/lib/libffi/ptest/testsuite/cls_ulonglong.exe
./usr/lib/libffi/ptest/testsuite/cls_8byte.exe
./usr/lib/libffi/ptest/testsuite/closure_simple.exe
./usr/lib/libffi/ptest/testsuite/cls_2byte.exe
./usr/lib/libffi/ptest/testsuite/cls_align_longdouble_split.exe
./usr/lib/libffi/ptest/testsuite/float1.exe
./usr/lib/libffi/ptest/testsuite/cls_6byte.exe
./usr/lib/libffi/ptest/testsuite/cls_uchar.exe
./usr/lib/libffi/ptest/testsuite/cls_uchar_va.exe
./usr/lib/libffi/ptest/testsuite/cls_9byte2.exe
./usr/lib/libffi/ptest/testsuite/stret_medium2.exe
./usr/lib/libffi/ptest/testsuite/cls_align_double.exe
./usr/lib/libffi/ptest/testsuite/return_sl.exe
./usr/lib/libffi/ptest/testsuite/va_struct1.exe
./usr/lib/libffi/ptest/testsuite/many2.exe
./usr/lib/libffi/ptest/testsuite/struct1.exe
./usr/lib/libffi/ptest/testsuite/nested_struct7.exe
./usr/lib/libffi/ptest/testsuite/closure_fn3.exe
./usr/lib/libffi/ptest/testsuite/cls_longdouble.exe
./usr/lib/libffi/ptest/testsuite/float4.exe
./usr/lib/libffi/ptest/testsuite/return_dbl2.exe
./usr/lib/libffi/ptest/testsuite/closure_fn4.exe
./usr/lib/libffi/ptest/testsuite/return_fl.exe
./usr/lib/libffi/ptest/testsuite/cls_sshort.exe
./usr/lib/libffi/ptest/testsuite/return_uc.exe
./usr/lib/libffi/ptest/testsuite/cls_align_sint64.exe
./usr/lib/libffi/ptest/testsuite/cls_18byte.exe
./usr/lib/libffi/ptest/testsuite/nested_struct.exe
./usr/lib/libffi/ptest/testsuite/cls_multi_ushortchar.exe
./usr/lib/libffi/ptest/testsuite/cls_7byte.exe
./usr/lib/libffi/ptest/testsuite/stret_medium.exe
./usr/lib/libffi/ptest/testsuite/cls_multi_sshort.exe
./usr/lib/libffi/ptest/testsuite/struct8.exe
./usr/lib/libffi/ptest/testsuite/cls_align_uint32.exe
./usr/lib/libffi/ptest/testsuite/cls_align_float.exe
./usr/lib/libffi/ptest/testsuite/struct4.exe
./usr/lib/libffi/ptest/testsuite/float2.exe
./usr/lib/libffi/ptest/testsuite/struct9.exe
./usr/lib/libffi/ptest/testsuite/cls_pointer.exe
./usr/lib/libffi/ptest/testsuite/return_ul.exe
./usr/lib/libffi/ptest/testsuite/cls_sint.exe
./usr/lib/libffi/ptest/testsuite/cls_multi_uchar.exe
./usr/lib/libffi/ptest/testsuite/stret_large2.exe
./usr/lib/libffi/ptest/testsuite/libffi.sum
./usr/lib/libffi/ptest/testsuite/closure_fn5.exe
./usr/lib/libffi/ptest/testsuite/huge_struct.exe
./usr/lib/libffi/ptest/testsuite/cls_20byte1.exe
./usr/lib/libffi/ptest/testsuite/return_dbl1.exe
./usr/lib/libffi/ptest/testsuite/cls_align_sint32.exe
./usr/lib/libffi/ptest/testsuite/cls_20byte.exe
./usr/lib/libffi/ptest/testsuite/struct6.exe
./usr/lib/libffi/ptest/testsuite/err_bad_typedef.exe
./usr/lib/libffi/ptest/testsuite/return_fl1.exe
./usr/lib/libffi/ptest/testsuite/struct7.exe
./usr/lib/libffi/ptest/testsuite/cls_6_1_byte.exe
./usr/lib/libffi/ptest/testsuite/cls_multi_schar.exe
./usr/lib/libffi/ptest/testsuite/va_1.exe
./usr/lib/libffi/ptest/testsuite/cls_3_1byte.exe
./usr/lib/libffi/ptest/testsuite/nested_struct1.exe
./usr/lib/libffi/ptest/testsuite/return_ll.exe
./usr/lib/libffi/ptest/testsuite/err_bad_abi.exe
./usr/lib/libffi/ptest/testsuite/promotion.exe
./usr/lib/libffi/ptest/testsuite/cls_align_pointer.exe
./usr/lib/libffi/ptest/testsuite/cls_64byte.exe
./usr/lib/libffi/ptest/testsuite/nested_struct2.exe
./usr/lib/libffi/ptest/testsuite/lib/wrapper.exp
./usr/lib/libffi/ptest/testsuite/lib/libffi.exp
./usr/lib/libffi/ptest/testsuite/lib/target-libpath.exp
./usr/lib/libffi/ptest/testsuite/cls_align_longdouble_split2.exe
./usr/lib/libffi/ptest/testsuite/cls_3byte2.exe
./usr/lib/libffi/ptest/testsuite/site.exp
./usr/lib/libffi/ptest/testsuite/many.exe
./usr/lib/libffi/ptest/testsuite/testclosure.exe
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_20byte1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_longdouble_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_schar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn5.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_sint16.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct8.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_3byte1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_uchar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_3_1byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/err_bad_abi.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_loc_fn0.c
./usr/lib/libffi/ptest/testsuite/libffi.call/unwindtest_ffi_call.cc
./usr/lib/libffi/ptest/testsuite/libffi.call/stret_medium2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_ushortchar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/err_bad_typedef.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_dbl2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_6byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct9.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_7_1_byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn6.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/stret_large2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_simple.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_19byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_double.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_uint_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_12byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/va_struct1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/stret_medium.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_longdouble.c
./usr/lib/libffi/ptest/testsuite/libffi.call/ffitest.h
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_schar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct7.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_uint.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_5_1_byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_9byte2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/va_struct2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_sshort.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct7.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_ushort.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_24byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct6.c
./usr/lib/libffi/ptest/testsuite/libffi.call/problem1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_4byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_pointer.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_dbl1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_dbls_struct.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_2byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/uninitialized.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_1_1byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_sint64.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_ul.c
./usr/lib/libffi/ptest/testsuite/libffi.call/huge_struct.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_double_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct11.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_ll.c
./usr/lib/libffi/ptest/testsuite/libffi.call/testclosure.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_sint.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_fl.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_ll1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_fl1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_longdouble_split2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/va_struct3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/call.exp
./usr/lib/libffi/ptest/testsuite/libffi.call/return_uc.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_longdouble_split.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_uint16.c
./usr/lib/libffi/ptest/testsuite/libffi.call/negint.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn0.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_ushort_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_fl3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/unwindtest.cc
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_6_1_byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float.c
./usr/lib/libffi/ptest/testsuite/libffi.call/closure_fn4.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float4.c
./usr/lib/libffi/ptest/testsuite/libffi.call/many2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_pointer_stack.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_uchar_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct4.c
./usr/lib/libffi/ptest/testsuite/libffi.call/many.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct8.c
./usr/lib/libffi/ptest/testsuite/libffi.call/va_1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_3byte2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_sl.c
./usr/lib/libffi/ptest/testsuite/libffi.call/strlen3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_double.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_ldl.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_8byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_7byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_dbl.c
./usr/lib/libffi/ptest/testsuite/libffi.call/float3.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_ushort.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_20byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_sshort.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_4_1byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_18byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_sc.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_ulong_va.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_sint32.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_pointer.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_ulonglong.c
./usr/lib/libffi/ptest/testsuite/libffi.call/strlen2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct4.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_uint32.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct10.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_float.c
./usr/lib/libffi/ptest/testsuite/libffi.call/struct5.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_5byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_float.c
./usr/lib/libffi/ptest/testsuite/libffi.call/strlen.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_multi_sshortchar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/pyobjc-tc.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_uchar.c
./usr/lib/libffi/ptest/testsuite/libffi.call/stret_large.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct6.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_9byte1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_longdouble.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_align_uint64.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_64byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct5.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_struct_va1.c
./usr/lib/libffi/ptest/testsuite/libffi.call/nested_struct9.c
./usr/lib/libffi/ptest/testsuite/libffi.call/promotion.c
./usr/lib/libffi/ptest/testsuite/libffi.call/return_fl2.c
./usr/lib/libffi/ptest/testsuite/libffi.call/cls_16byte.c
./usr/lib/libffi/ptest/testsuite/libffi.call/strlen4.c
./usr/lib/libffi/ptest/testsuite/strlen3.exe
./usr/lib/libffi/ptest/testsuite/cls_16byte.exe
./usr/lib/libffi/ptest/testsuite/cls_multi_sshortchar.exe
./usr/lib/libffi/ptest/testsuite/unwindtest.exe
./usr/lib/libffi/ptest/testsuite/return_ldl.exe
./usr/lib/libffi/ptest/testsuite/cls_24byte.exe
./usr/lib/libffi/ptest/testsuite/cls_align_uint64.exe
./usr/lib/libffi/ptest/testsuite/va_struct3.exe
./usr/lib/libffi/ptest/testsuite/cls_struct_va1.exe
./usr/lib/libffi/ptest/testsuite/negint.exe
./usr/lib/libffi/ptest/testsuite/closure_fn0.exe
./usr/lib/libffi/ptest/testsuite/cls_uint.exe
./usr/lib/libffi/ptest/testsuite/closure_loc_fn0.exe
./usr/lib/libffi/ptest/testsuite/float_va.exe
./usr/lib/libffi/ptest/testsuite/return_dbl.exe
./usr/lib/libffi/ptest/testsuite/nested_struct3.exe
./usr/lib/libffi/ptest/testsuite/strlen2.exe
./usr/lib/libffi/ptest/testsuite/cls_4byte.exe
./usr/lib/libffi/ptest/testsuite/cls_float.exe
./usr/lib/libffi/ptest/testsuite/float.exe
./usr/lib/libffi/ptest/testsuite/closure_fn6.exe
./usr/lib/libffi/ptest/testsuite/closure_fn1.exe
./usr/lib/libffi/ptest/testsuite/va_struct2.exe
./usr/lib/libffi/ptest/testsuite/nested_struct4.exe
./usr/lib/libffi/ptest/testsuite/strlen4.exe
./usr/lib/libffi/ptest/testsuite/nested_struct8.exe
./usr/lib/libffi/ptest/testsuite/cls_uint_va.exe
./usr/lib/libffi/ptest/testsuite/unwindtest_ffi_call.exe
./usr/lib/libffi/ptest/testsuite/Makefile.am
./usr/lib/libffi/ptest/testsuite/return_sc.exe
./usr/lib/libffi/ptest/testsuite/return_fl2.exe
./usr/lib/libffi/ptest/testsuite/cls_7_1_byte.exe
./usr/lib/libffi/ptest/testsuite/nested_struct9.exe
./usr/lib/libffi/ptest/testsuite/pyobjc-tc.exe
./usr/lib/libffi/ptest/testsuite/cls_3byte1.exe
./usr/lib/libffi/ptest/testsuite/struct3.exe
./usr/lib/libffi/ptest/testsuite/cls_multi_ushort.exe
./usr/lib/libffi/ptest/testsuite/problem1.exe
./usr/lib/libffi/ptest/testsuite/cls_19byte.exe
./usr/lib/libffi/ptest/testsuite/cls_5_1_byte.exe
./usr/lib/libffi/ptest/testsuite/float3.exe
./usr/lib/libffi/ptest/testsuite/Makefile
./usr/lib/libffi/ptest/testsuite/Makefile.in
./usr/lib/libffi/ptest/testsuite/cls_9byte1.exe
./usr/lib/libffi/ptest/testsuite/strlen.exe
./usr/lib/libffi/ptest/testsuite/cls_double_va.exe
./usr/lib/libffi/ptest/testsuite/return_ll1.exe
./usr/lib/libffi/ptest/testsuite/cls_align_uint16.exe
./usr/lib/libffi/ptest/testsuite/nested_struct5.exe
./usr/lib/libffi/ptest/testsuite/struct5.exe
./usr/lib/libffi/ptest/testsuite/closure_fn2.exe
./usr/lib/libffi/ptest/testsuite/return_fl3.exe
./usr/lib/libffi/ptest/testsuite/cls_pointer_stack.exe
./usr/lib/libffi/ptest/testsuite/cls_schar.exe
./usr/lib/libffi/ptest/testsuite/cls_align_sint16.exe
./usr/lib/libffi/ptest/include/ffi.h
./usr/lib/libffi/ptest/include/Makefile
./usr/lib/libffi/ptest/Makefile
./usr/lib/libffi/ptest/libffi_convenience.a
./usr/lib/libffi/ptest/src/java_raw_api.lo
./usr/lib/libffi/ptest/src/raw_api.lo
./usr/lib/libffi/ptest/src/aarch64/.libs/ffi.o
./usr/lib/libffi/ptest/src/aarch64/.libs/sysv.o
./usr/lib/libffi/ptest/src/aarch64/.dirstamp
./usr/lib/libffi/ptest/src/aarch64/ffi.lo
./usr/lib/libffi/ptest/src/aarch64/sysv.lo
./usr/lib/libffi/ptest/src/aarch64/.deps/.dirstamp
./usr/lib/libffi/ptest/src/.libs/prep_cif.o
./usr/lib/libffi/ptest/src/.libs/types.o
./usr/lib/libffi/ptest/src/.libs/closures.o
./usr/lib/libffi/ptest/src/.libs/raw_api.o
./usr/lib/libffi/ptest/src/.libs/java_raw_api.o
./usr/lib/libffi/ptest/src/.dirstamp
./usr/lib/libffi/ptest/src/types.lo
./usr/lib/libffi/ptest/src/prep_cif.lo
./usr/lib/libffi/ptest/src/.deps/.dirstamp
./usr/lib/libffi/ptest/src/closures.lo
```